### PR TITLE
Fix timestamps for incomplete CTC checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ pip install -r requirements.txt
 
 # Capability boundaries
 
-- [ ] Reliable checkpoint-native timestamps
-  > The released Fun-ASR-Nano `model.pt` checkpoint does not include trained `ctc_decoder.*` / `ctc.*` weights. Any timestamp output is therefore not reliable. For accurate character-level timestamps, use Paraformer, for example `AutoModel(model="paraformer-zh", vad_model="fsmn-vad", ...)`. See [issue #106](https://github.com/QwenAudio/Fun-ASR/issues/106).
+- [x] Checkpoint-native character timestamps (hub-specific checkpoint state)
+  > The current ModelScope `FunAudioLLM/Fun-ASR-Nano-2512` checkpoint includes all 86 trained `ctc_decoder.*` / `ctc.*` tensors (`model.pt` SHA-256 `81fec8616083c69377f3ceef36aba3655660ee0ca69a5d4a1e9810cd340ca499`) and produces native CTC timestamps. The Hugging Face checkpoint at revision `272c57b82523ada6fd87095e955f8e29100979ab` is still the older text-only artifact (`model.pt` SHA-256 `55ae0d2fee369f0f11cce0795f6927934ad17cf11b278a7e56a51272074160bb`) with no CTC tensors. When this repository's current `model.py` is used with `funasr>=1.3.26`, incomplete checkpoints fail closed: transcription remains available, but `timestamps` are omitted instead of returning random 60 ms alignments. Use `hub="ms"` for checkpoint-native timestamps until the Hugging Face artifact and remote code are synchronized. See [issue #70](https://github.com/QwenAudio/Fun-ASR/issues/70) and [FunASR #3496](https://github.com/modelscope/FunASR/issues/3496).
 - [ ] Checkpoint-native speaker diarization
   > Fun-ASR-Nano and Fun-ASR-MLT-Nano do not emit speaker labels by themselves. Compose them in FunASR with the separate `fsmn-vad` and `cam++` models, as shown below.
 - [x] Model training

--- a/README_ja.md
+++ b/README_ja.md
@@ -64,7 +64,7 @@ pip install -r requirements.txt
 
 # 機能の境界
 
-- **タイムスタンプ**：公開済みNano checkpointには学習済みCTC重みが含まれないため、checkpoint由来の文字単位タイムスタンプは信頼できません。正確な文字単位タイムスタンプにはParaformerを使用してください（[issue #106](https://github.com/QwenAudio/Fun-ASR/issues/106)）。
+- **タイムスタンプ（配布元ごとの状態）**：現在のModelScope版`FunAudioLLM/Fun-ASR-Nano-2512`には、学習済みの`ctc_decoder.*` / `ctc.*`全86テンソルが含まれています（`model.pt` SHA-256：`81fec8616083c69377f3ceef36aba3655660ee0ca69a5d4a1e9810cd340ca499`）。一方、Hugging Face revision `272c57b82523ada6fd87095e955f8e29100979ab`はCTCテンソルを含まない旧テキスト専用版です（SHA-256：`55ae0d2fee369f0f11cce0795f6927934ad17cf11b278a7e56a51272074160bb`）。このリポジトリの現在の`model.py`を`funasr>=1.3.26`と共に使用すると、不完全なcheckpointのCTCを無効化し、転写テキストは返しますが、ランダムな60 msタイムスタンプは返しません。Hugging Faceの重みとremote codeの同期が完了するまでは、文字単位タイムスタンプに`hub="ms"`を使用してください（[issue #70](https://github.com/QwenAudio/Fun-ASR/issues/70)、[FunASR #3496](https://github.com/modelscope/FunASR/issues/3496)）。
 - **話者分離**：Nano/MLT checkpoint自体は話者ラベルを出力しません。FunASRで`fsmn-vad`と`cam++`を組み合わせます。
 
 # 使い方 🛠️

--- a/README_ko.md
+++ b/README_ko.md
@@ -63,7 +63,7 @@ pip install -r requirements.txt
 
 # 기능 범위
 
-- **타임스탬프**: 공개된 Nano 체크포인트에는 학습된 CTC 가중치가 없어 체크포인트 기반 문자 단위 타임스탬프를 신뢰할 수 없습니다. 정확한 문자 단위 타임스탬프에는 Paraformer를 사용하세요([issue #106](https://github.com/QwenAudio/Fun-ASR/issues/106)).
+- **타임스탬프(호스팅 소스별 상태)**: 현재 ModelScope의 `FunAudioLLM/Fun-ASR-Nano-2512` 체크포인트에는 학습된 `ctc_decoder.*` / `ctc.*` 텐서 86개가 모두 포함되어 있습니다(`model.pt` SHA-256: `81fec8616083c69377f3ceef36aba3655660ee0ca69a5d4a1e9810cd340ca499`). 반면 Hugging Face revision `272c57b82523ada6fd87095e955f8e29100979ab`는 CTC 텐서가 없는 이전 텍스트 전용 아티팩트입니다(SHA-256: `55ae0d2fee369f0f11cce0795f6927934ad17cf11b278a7e56a51272074160bb`). 이 저장소의 현재 `model.py`를 `funasr>=1.3.26`과 함께 사용하면 불완전한 체크포인트의 CTC를 비활성화하여 텍스트 전사는 유지하되 임의의 60 ms 타임스탬프는 반환하지 않습니다. Hugging Face 가중치와 remote code가 동기화되기 전에는 문자 단위 타임스탬프에 `hub="ms"`를 사용하세요([issue #70](https://github.com/QwenAudio/Fun-ASR/issues/70), [FunASR #3496](https://github.com/modelscope/FunASR/issues/3496)).
 - **화자 분리**: Nano/MLT 체크포인트 자체는 화자 레이블을 출력하지 않습니다. FunASR에서 `fsmn-vad`와 `cam++`를 조합합니다.
 
 # 사용법 🛠️

--- a/README_zh.md
+++ b/README_zh.md
@@ -68,8 +68,8 @@ pip install -r requirements.txt
 
 # 能力边界
 
-- [ ] 可靠的 checkpoint 原生时间戳
-  > 当前发布的 Fun-ASR-Nano `model.pt` checkpoint 不包含已训练的 `ctc_decoder.*` / `ctc.*` 权重，因此其时间戳输出并不可靠。需要准确的字级时间戳时，请改用 Paraformer，例如 `AutoModel(model="paraformer-zh", vad_model="fsmn-vad", ...)`。详情见 [issue #106](https://github.com/QwenAudio/Fun-ASR/issues/106)。
+- [x] checkpoint 原生字级时间戳（需区分模型托管源）
+  > 当前 ModelScope `FunAudioLLM/Fun-ASR-Nano-2512` checkpoint 已包含全部 86 个训练后的 `ctc_decoder.*` / `ctc.*` 张量（`model.pt` SHA-256：`81fec8616083c69377f3ceef36aba3655660ee0ca69a5d4a1e9810cd340ca499`），可以输出原生 CTC 时间戳。Hugging Face revision `272c57b82523ada6fd87095e955f8e29100979ab` 仍是旧的纯文本权重（`model.pt` SHA-256：`55ae0d2fee369f0f11cce0795f6927934ad17cf11b278a7e56a51272074160bb`），不含 CTC 张量。使用本仓库当前 `model.py` 与 `funasr>=1.3.26` 时，不完整 checkpoint 会安全关闭 CTC：文本转写继续可用，但不会再返回随机的 60 ms 时间戳。Hugging Face 权重和远程代码同步前，需要原生时间戳请使用 `hub="ms"`。详见 [issue #70](https://github.com/QwenAudio/Fun-ASR/issues/70) 与 [FunASR #3496](https://github.com/modelscope/FunASR/issues/3496)。
 - [ ] checkpoint 原生说话人分离
   > Fun-ASR-Nano 和 Fun-ASR-MLT-Nano 本身不输出说话人标签；需在 FunASR 中组合独立的 `fsmn-vad` 与 `cam++` 模型。
 - [x] 支持模型训练

--- a/model.py
+++ b/model.py
@@ -23,6 +23,52 @@ from tools.utils import forced_align
 dtype_map = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}
 
 
+def _normalize_checkpoint_state(state):
+    while isinstance(state, dict):
+        wrapped = next(
+            (
+                state[key]
+                for key in ("state_dict", "model_state_dict", "model")
+                if isinstance(state.get(key), dict)
+            ),
+            None,
+        )
+        if wrapped is None or wrapped is state:
+            break
+        state = wrapped
+
+    return {
+        key[len("module.") :] if key.startswith("module.") else key: value
+        for key, value in state.items()
+    }
+
+
+def _disable_incomplete_ctc(model, loaded_keys):
+    if model.ctc_decoder is None or model.ctc is None:
+        return
+
+    expected = {f"ctc_decoder.{key}" for key in model.ctc_decoder.state_dict()}
+    expected.update(f"ctc.{key}" for key in model.ctc.state_dict())
+    missing = sorted(expected.difference(loaded_keys))
+    if not missing:
+        return
+
+    preview = ", ".join(missing[:3])
+    suffix = "" if len(missing) <= 3 else ", ..."
+    logging.warning(
+        "Disabling CTC timestamps because the checkpoint did not initialize "
+        "%d of %d required CTC tensors (%s%s). Text transcription remains available.",
+        len(missing),
+        len(expected),
+        preview,
+        suffix,
+    )
+    model.ctc_decoder = None
+    model.ctc = None
+    model.ctc_tokenizer = None
+    model.blank_id = None
+
+
 @tables.register("model_classes", "FunASRNano")
 class FunASRNano(nn.Module):
     def __init__(
@@ -107,6 +153,7 @@ class FunASRNano(nn.Module):
 
         # ctc decoder
         self.ctc_decoder = None
+        self._externally_loaded_ctc_keys = set()
         # TODO: fix table name
         ctc_decoder_class = tables.adaptor_classes.get(kwargs.get("ctc_decoder", None))
         if ctc_decoder_class is not None:
@@ -133,8 +180,15 @@ class FunASRNano(nn.Module):
             self.ctc_decoder = ctc_decoder_class(**ctc_decoder_conf)
             init_param_path = ctc_decoder_conf.get("init_param_path", None)
             if init_param_path is not None:
-                src_state = torch.load(init_param_path, map_location="cpu")
+                src_state = _normalize_checkpoint_state(
+                    torch.load(init_param_path, map_location="cpu")
+                )
                 flag = self.ctc_decoder.load_state_dict(src_state, strict=False)
+                self._externally_loaded_ctc_keys.update(
+                    f"ctc_decoder.{key}"
+                    for key in self.ctc_decoder.state_dict()
+                    if key in src_state
+                )
                 logging.info(f"Loading ctc_decoder ckpt: {init_param_path}, status: {flag}")
             freeze = ctc_decoder_conf.get("freeze", False)
             if freeze:
@@ -157,6 +211,11 @@ class FunASRNano(nn.Module):
         self.length_normalized_loss = length_normalized_loss
         rank = int(os.environ.get("RANK", 0))
         logging.info(f"rank: {rank}, model is builded.")
+
+    def on_pretrained_model_loaded(self, loaded_keys):
+        """Disable timestamp inference when the checkpoint lacks trained CTC weights."""
+        loaded_keys = set(loaded_keys).union(self._externally_loaded_ctc_keys)
+        _disable_incomplete_ctc(self, loaded_keys)
 
     def forward(
         self,

--- a/tests/test_checkpoint_ctc_guard.py
+++ b/tests/test_checkpoint_ctc_guard.py
@@ -1,0 +1,52 @@
+import torch
+
+from model import FunASRNano
+
+
+def _model_with_ctc_modules():
+    model = object.__new__(FunASRNano)
+    torch.nn.Module.__init__(model)
+    model.ctc_decoder = torch.nn.Linear(2, 2)
+    model.ctc = torch.nn.Linear(2, 2)
+    model.ctc_tokenizer = object()
+    model.blank_id = 2
+    model._externally_loaded_ctc_keys = set()
+    return model
+
+
+def _complete_ctc_keys(model):
+    keys = {f"ctc_decoder.{key}" for key in model.ctc_decoder.state_dict()}
+    keys.update(f"ctc.{key}" for key in model.ctc.state_dict())
+    return keys
+
+
+def test_checkpoint_without_ctc_weights_disables_timestamp_modules():
+    model = _model_with_ctc_modules()
+
+    model.on_pretrained_model_loaded(set())
+
+    assert model.ctc_decoder is None
+    assert model.ctc is None
+    assert model.ctc_tokenizer is None
+    assert model.blank_id is None
+
+
+def test_checkpoint_with_complete_ctc_weights_keeps_timestamp_modules():
+    model = _model_with_ctc_modules()
+
+    model.on_pretrained_model_loaded(_complete_ctc_keys(model))
+
+    assert model.ctc_decoder is not None
+    assert model.ctc is not None
+    assert model.ctc_tokenizer is not None
+    assert model.blank_id == 2
+
+
+def test_external_ctc_checkpoint_keys_count_toward_completeness():
+    model = _model_with_ctc_modules()
+    model._externally_loaded_ctc_keys = _complete_ctc_keys(model)
+
+    model.on_pretrained_model_loaded(set())
+
+    assert model.ctc_decoder is not None
+    assert model.ctc is not None

--- a/tests/test_timestamp_documentation.py
+++ b/tests/test_timestamp_documentation.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_all_readmes_document_hub_specific_timestamp_checkpoint_state():
+    for name in ("README.md", "README_zh.md", "README_ja.md", "README_ko.md"):
+        text = (ROOT / name).read_text(encoding="utf-8")
+        assert "ModelScope" in text, name
+        assert "Hugging Face" in text, name
+        assert "272c57b82523ada6fd87095e955f8e29100979ab" in text, name
+        assert "81fec8616083c69377f3ceef36aba3655660ee0ca69a5d4a1e9810cd340ca499" in text, name
+        assert "55ae0d2fee369f0f11cce0795f6927934ad17cf11b278a7e56a51272074160bb" in text, name
+
+
+def test_readme_does_not_claim_every_released_checkpoint_lacks_ctc_weights():
+    text = (ROOT / "README.md").read_text(encoding="utf-8")
+
+    assert "The released Fun-ASR-Nano `model.pt` checkpoint does not include" not in text


### PR DESCRIPTION
## Summary

- fail closed when a checkpoint does not initialize every configured CTC tensor
- preserve text transcription while omitting untrained, mechanically spaced timestamps
- document the current ModelScope and Hugging Face checkpoint boundary in four languages

## Root cause

The Hugging Face `FunAudioLLM/Fun-ASR-Nano-2512` artifact at revision
`272c57b82523ada6fd87095e955f8e29100979ab` contains no `ctc_decoder.*` or
`ctc.*` tensors. The configured CTC modules were therefore left randomly
initialized and still entered forced alignment, producing plausible-looking
60 ms token intervals. The current ModelScope checkpoint contains all 86 CTC
tensors and is unaffected.

## Verification

- `PYTHONPATH="$PWD:<cu128-site-packages>" python -m pytest -q tests`: 28 passed
- `python -m py_compile model.py tests/test_checkpoint_ctc_guard.py tests/test_timestamp_documentation.py`
- `git diff --cached --check`
- HF old checkpoint, exact audio: text preserved, CTC disabled, no `timestamps`
- ModelScope current checkpoint, same audio: 14 timestamps, 0.78s to 5.16s, 13 positive gaps, mean alignment score 0.90114

Checkpoint SHA-256:

- ModelScope: `81fec8616083c69377f3ceef36aba3655660ee0ca69a5d4a1e9810cd340ca499`
- Hugging Face: `55ae0d2fee369f0f11cce0795f6927934ad17cf11b278a7e56a51272074160bb`

Related to #70 and modelscope/FunASR#3496. This PR intentionally does not
close #70; the issue should remain open until the reporter verifies the
published model/code path.
