### PR TITLE
Add reproducible Japanese CER evaluation

### DIFF
--- a/docs/finetune.md
+++ b/docs/finetune.md
@@ -112,3 +112,11 @@ python tools/whisper_mix_normalize.py output.txt output_norm.txt
 compute-wer data/val_norm.txt output_norm.txt cer.txt
 tail -n8 cer.txt
 ```
+
+For Japanese, normalize both files to katakana with OpenJTalk before computing
+CER. The one-command workflow and reproducibility options are documented in
+[Japanese CER evaluation](japanese_cer.md):
+
+```bash
+python tools/compute_ja_cer.py data/val_text.txt output.txt japanese_cer.txt
+```

--- a/docs/finetune_zh.md
+++ b/docs/finetune_zh.md
@@ -112,3 +112,11 @@ python tools/whisper_mix_normalize.py output.txt output_norm.txt
 compute-wer data/val_norm.txt output_norm.txt cer.txt
 tail -n8 cer.txt
 ```
+
+日语评测需要先用 OpenJTalk 将参考文本和识别结果统一转换为片假名字符序列，再计算
+CER。完整用法及固定词典版本的方法见
+[Japanese CER evaluation](japanese_cer.md)：
+
+```bash
+python tools/compute_ja_cer.py data/val_text.txt output.txt japanese_cer.txt
+```

--- a/docs/japanese_cer.md
+++ b/docs/japanese_cer.md
@@ -1,0 +1,101 @@
+# Japanese CER evaluation
+
+Fun-ASR evaluates Japanese transcripts after converting both the reference and
+the hypothesis to katakana with OpenJTalk. This makes the score depend on the
+pronunciation rather than the original mix of kanji, hiragana, and katakana.
+The normalized character sequences are then aligned by `compute-wer`.
+
+## Installation
+
+The repository requirements already include `pyopenjtalk-plus` and
+`compute-wer`:
+
+```bash
+pip install -r requirements.txt
+```
+
+`pyopenjtalk-plus` ships with an OpenJTalk-compatible dictionary. To reproduce
+a benchmark that used a particular OpenJTalk 1.11 dictionary, pass that
+dictionary directory explicitly with `--open-jtalk-dict`.
+
+## Input format
+
+Reference and hypothesis files use one utterance per line. The first
+whitespace-separated field is the utterance ID and the remaining text is the
+transcript. IDs must match between the two files.
+
+```text
+utt-001 今日は晴れです
+utt-002 音声認識のテストです
+```
+
+Some evaluation pipelines write three columns: audio path, utterance ID, and
+text. Select that format explicitly so the path and ID are not passed to
+OpenJTalk:
+
+```text
+/data/001.wav utt-001 今日は晴れです
+```
+
+```bash
+python tools/compute_ja_cer.py \
+  label_domain \
+  text_domain \
+  japanese_cer.txt \
+  --input-format path-id-text
+```
+
+## One-command evaluation
+
+```bash
+python tools/compute_ja_cer.py \
+  reference.txt \
+  hypothesis.txt \
+  japanese_cer.txt
+```
+
+Keep the katakana inputs used for scoring when an audit or a regression test
+needs them:
+
+```bash
+python tools/compute_ja_cer.py \
+  reference.txt \
+  hypothesis.txt \
+  japanese_cer.txt \
+  --normalized-dir normalized
+```
+
+Use an exact OpenJTalk dictionary for reproducible comparisons with an
+existing benchmark:
+
+```bash
+python tools/compute_ja_cer.py \
+  reference.txt \
+  hypothesis.txt \
+  japanese_cer.txt \
+  --open-jtalk-dict /path/to/open_jtalk_dic_utf_8-1.11
+```
+
+For example, `今日は晴れです` and `きょうは晴れです` both normalize to:
+
+```text
+キ ョ ー ワ ハ レ デ ス
+```
+
+OpenJTalk predicts readings from context. Orthographic variants are only
+treated as equal when their predicted katakana sequences are equal. For
+example, `良い` may be read as `ヨイ`, while `いい` is read as `イイ`.
+
+## Normalization only
+
+The underlying normalizer remains available independently:
+
+```bash
+python tools/whisper_mix_normalize.py \
+  reference.txt \
+  reference.kana.txt \
+  --language ja
+```
+
+Japanese conversion failures are fatal. The tool does not silently score the
+original unnormalized text when OpenJTalk or its dictionary fails.

--- a/tests/test_japanese_cer.py
+++ b/tests/test_japanese_cer.py
@@ -89,17 +89,27 @@ class JapaneseNormalizerTest(unittest.TestCase):
             )
 
             self.assertNotEqual(default_jtalk_id, id(explicit_jtalk))
-            with mock.patch.object(
-                whisper_mix_normalize.pyopenjtalk,
-                "g2p",
-                wraps=whisper_mix_normalize.pyopenjtalk.g2p,
-            ) as g2p:
+            self.assertEqual(
+                explicit_jtalk.g2p("テスト", kana=True),
                 whisper_mix_normalize.safe_ja_g2p(
                     "テスト",
                     jtalk=explicit_jtalk,
-                )
+                ),
+            )
 
-            self.assertIs(g2p.call_args.kwargs["jtalk"], explicit_jtalk)
+            long_text = "今日は晴れです。" * 20
+            expected_chunks = [
+                explicit_jtalk.g2p(long_text[i : i + 100], kana=True)
+                for i in range(0, len(long_text), 100)
+            ]
+            self.assertEqual(
+                " ".join(expected_chunks),
+                whisper_mix_normalize.safe_ja_g2p(
+                    long_text,
+                    max_length=100,
+                    jtalk=explicit_jtalk,
+                ),
+            )
 
 
 class JapaneseCerTest(unittest.TestCase):

--- a/tests/test_japanese_cer.py
+++ b/tests/test_japanese_cer.py
@@ -70,6 +70,37 @@ class JapaneseNormalizerTest(unittest.TestCase):
         ):
             whisper_mix_normalize.configure_open_jtalk_dict(temp_dir)
 
+    def test_explicit_dictionary_uses_dedicated_frontend_after_default_init(self):
+        # Reproduce the process-lifetime ordering that previously caused an
+        # explicit dictionary path to reuse pyopenjtalk's cached default
+        # frontend.
+        whisper_mix_normalize.pyopenjtalk.g2p("テスト", kana=True)
+        with whisper_mix_normalize.pyopenjtalk._global_jtalk() as default_jtalk:
+            default_jtalk_id = id(default_jtalk)
+
+        default_dict = Path(
+            whisper_mix_normalize.pyopenjtalk.OPEN_JTALK_DICT_DIR.decode("utf-8")
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            explicit_dict = Path(temp_dir) / "open_jtalk_dic_utf_8-1.11"
+            explicit_dict.symlink_to(default_dict, target_is_directory=True)
+            explicit_jtalk = whisper_mix_normalize.configure_open_jtalk_dict(
+                explicit_dict
+            )
+
+            self.assertNotEqual(default_jtalk_id, id(explicit_jtalk))
+            with mock.patch.object(
+                whisper_mix_normalize.pyopenjtalk,
+                "g2p",
+                wraps=whisper_mix_normalize.pyopenjtalk.g2p,
+            ) as g2p:
+                whisper_mix_normalize.safe_ja_g2p(
+                    "テスト",
+                    jtalk=explicit_jtalk,
+                )
+
+            self.assertIs(g2p.call_args.kwargs["jtalk"], explicit_jtalk)
+
 
 class JapaneseCerTest(unittest.TestCase):
     def test_runs_compute_wer_on_normalized_files(self):

--- a/tests/test_japanese_cer.py
+++ b/tests/test_japanese_cer.py
@@ -1,0 +1,141 @@
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from tools import compute_ja_cer, whisper_mix_normalize
+
+
+class JapaneseNormalizerTest(unittest.TestCase):
+    def test_kana_normalization_outputs_character_sequence(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "source.txt"
+            output = root / "output.txt"
+            source.write_text("utt-1 今日は晴れです\n", encoding="utf-8")
+
+            with mock.patch.object(
+                whisper_mix_normalize.pyopenjtalk,
+                "g2p",
+                return_value="キョーワハレデス",
+            ):
+                whisper_mix_normalize.normalize_text(source, output, kana=True)
+
+            self.assertEqual(
+                "utt-1\tキ ョ ー ワ ハ レ デ ス\n",
+                output.read_text(encoding="utf-8"),
+            )
+
+    def test_openjtalk_failure_is_not_silently_ignored(self):
+        with (
+            mock.patch.object(
+                whisper_mix_normalize.pyopenjtalk,
+                "g2p",
+                side_effect=ValueError("invalid dictionary"),
+            ),
+            self.assertRaisesRegex(RuntimeError, "OpenJTalk failed"),
+        ):
+            whisper_mix_normalize.safe_ja_g2p("今日は晴れです")
+
+    def test_path_id_text_format_excludes_path_and_id_from_g2p(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "source.txt"
+            output = root / "output.txt"
+            source.write_text("audio.wav utt-ja-1 今日は晴れです\n", encoding="utf-8")
+
+            with mock.patch.object(
+                whisper_mix_normalize.pyopenjtalk,
+                "g2p",
+                return_value="キョーワハレデス",
+            ) as g2p:
+                whisper_mix_normalize.normalize_text(
+                    source,
+                    output,
+                    kana=True,
+                    input_format="path-id-text",
+                )
+
+            g2p.assert_called_once_with("今日は晴れです", kana=True)
+            self.assertEqual(
+                "utt-ja-1\tキ ョ ー ワ ハ レ デ ス\n",
+                output.read_text(encoding="utf-8"),
+            )
+
+    def test_explicit_dictionary_requires_sys_dic(self):
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            self.assertRaisesRegex(RuntimeError, "missing sys.dic"),
+        ):
+            whisper_mix_normalize.configure_open_jtalk_dict(temp_dir)
+
+
+class JapaneseCerTest(unittest.TestCase):
+    def test_runs_compute_wer_on_normalized_files(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            reference = root / "reference.txt"
+            hypothesis = root / "hypothesis.txt"
+            report = root / "cer.txt"
+            normalized = root / "normalized"
+            reference.write_text("utt-1 今日は晴れです\n", encoding="utf-8")
+            hypothesis.write_text("utt-1 きょうは晴れです\n", encoding="utf-8")
+
+            def fake_normalize(source, destination, **kwargs):
+                del source, kwargs
+                Path(destination).write_text(
+                    "utt-1\tキ ョ ー ワ ハ レ デ ス\n", encoding="utf-8"
+                )
+
+            with (
+                mock.patch.object(
+                    compute_ja_cer, "normalize_text", side_effect=fake_normalize
+                ) as normalize,
+                mock.patch.object(
+                    compute_ja_cer.shutil, "which", return_value="/usr/bin/compute-wer"
+                ),
+                mock.patch.object(compute_ja_cer.subprocess, "run") as run,
+            ):
+                result = compute_ja_cer.compute_ja_cer(
+                    reference,
+                    hypothesis,
+                    report,
+                    normalized_dir=normalized,
+                )
+
+            self.assertEqual(report, result)
+            self.assertEqual(2, normalize.call_count)
+            run.assert_called_once_with(
+                [
+                    "/usr/bin/compute-wer",
+                    str(normalized / "reference.kana.txt"),
+                    str(normalized / "hypothesis.kana.txt"),
+                    str(report),
+                ],
+                check=True,
+            )
+
+    @unittest.skipUnless(
+        shutil.which("compute-wer") is not None,
+        "compute-wer is not installed",
+    )
+    def test_real_japanese_end_to_end(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            reference = root / "reference.txt"
+            hypothesis = root / "hypothesis.txt"
+            report = root / "cer.txt"
+            reference.write_text("utt-1 今日は晴れです\n", encoding="utf-8")
+            hypothesis.write_text("utt-1 きょうは晴れです\n", encoding="utf-8")
+
+            compute_ja_cer.compute_ja_cer(reference, hypothesis, report)
+
+            self.assertIn(
+                "Overall -> 0.00 %",
+                report.read_text(encoding="utf-8"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/compute_ja_cer.py
+++ b/tools/compute_ja_cer.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Compute Japanese CER after OpenJTalk kana normalization."""
+
+import argparse
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+if __package__:
+    from .whisper_mix_normalize import normalize_text
+else:  # Support ``python tools/compute_ja_cer.py``.
+    from whisper_mix_normalize import normalize_text
+
+
+def compute_ja_cer(
+    reference,
+    hypothesis,
+    output_file,
+    normalized_dir=None,
+    open_jtalk_dict=None,
+    input_format="id-text",
+):
+    """Normalize reference/hypothesis to katakana and run ``compute-wer``."""
+    compute_wer = shutil.which("compute-wer")
+    if compute_wer is None:
+        raise RuntimeError(
+            "compute-wer is not installed; run `pip install compute-wer` first"
+        )
+
+    reference = Path(reference)
+    hypothesis = Path(hypothesis)
+    output_file = Path(output_file)
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+
+    if normalized_dir is not None:
+        normalized_path = Path(normalized_dir)
+        normalized_path.mkdir(parents=True, exist_ok=True)
+        temp_context = None
+    else:
+        temp_context = tempfile.TemporaryDirectory(prefix="fun_asr_ja_cer_")
+        normalized_path = Path(temp_context.name)
+
+    try:
+        reference_norm = normalized_path / "reference.kana.txt"
+        hypothesis_norm = normalized_path / "hypothesis.kana.txt"
+        normalize_text(
+            reference,
+            reference_norm,
+            kana=True,
+            open_jtalk_dict=open_jtalk_dict,
+            input_format=input_format,
+        )
+        normalize_text(
+            hypothesis,
+            hypothesis_norm,
+            kana=True,
+            open_jtalk_dict=open_jtalk_dict,
+            input_format=input_format,
+        )
+        subprocess.run(
+            [compute_wer, str(reference_norm), str(hypothesis_norm), str(output_file)],
+            check=True,
+        )
+    finally:
+        if temp_context is not None:
+            temp_context.cleanup()
+
+    return output_file
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Convert Japanese reference and hypothesis text to katakana with "
+            "OpenJTalk, then compute character error rate with compute-wer."
+        )
+    )
+    parser.add_argument("reference", help="reference: utterance-id followed by text")
+    parser.add_argument("hypothesis", help="hypothesis: utterance-id followed by text")
+    parser.add_argument("output_file", help="alignment and CER report")
+    parser.add_argument(
+        "--normalized-dir",
+        help="keep normalized reference.kana.txt and hypothesis.kana.txt here",
+    )
+    parser.add_argument(
+        "--open-jtalk-dict",
+        help="optional OpenJTalk dictionary directory containing sys.dic",
+    )
+    parser.add_argument(
+        "--input-format",
+        choices=("id-text", "path-id-text"),
+        default="id-text",
+        help="input columns: 'utterance-id text' or 'audio-path utterance-id text'",
+    )
+    args = parser.parse_args()
+
+    compute_ja_cer(
+        args.reference,
+        args.hypothesis,
+        args.output_file,
+        normalized_dir=args.normalized_dir,
+        open_jtalk_dict=args.open_jtalk_dict,
+        input_format=args.input_format,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/whisper_mix_normalize.py
+++ b/tools/whisper_mix_normalize.py
@@ -1,16 +1,22 @@
-# -*- coding: utf-8 -*-
-#!/usr/bin/python
-# Author: Mengze Chen
+#!/usr/bin/env python3
+"""Normalize ASR transcripts before WER/CER scoring."""
 
+import argparse
+import os
 import re
-import sys
+from pathlib import Path
 
-import cn_tn as cn_tn
-import format5res as cn_itn
 import pyopenjtalk
 import zhconv
 from whisper_normalizer.basic import BasicTextNormalizer
 from whisper_normalizer.english import EnglishTextNormalizer
+
+if __package__:
+    from . import cn_tn
+    from . import format5res as cn_itn
+else:  # Support ``python tools/whisper_mix_normalize.py``.
+    import cn_tn
+    import format5res as cn_itn
 
 basic_normalizer = BasicTextNormalizer()
 english_normalizer = EnglishTextNormalizer()
@@ -37,44 +43,87 @@ def is_number(s):
     return re.match(pattern, s) is not None
 
 
+def configure_open_jtalk_dict(dict_dir):
+    """Configure an explicit OpenJTalk system dictionary directory."""
+    if dict_dir is None:
+        return
+
+    dict_path = Path(dict_dir).expanduser().resolve()
+    if not (dict_path / "sys.dic").is_file():
+        raise RuntimeError(f"OpenJTalk dictionary is missing sys.dic: {dict_path}")
+
+    # pyopenjtalk reads this value when its global frontend is initialized.
+    os.environ["OPEN_JTALK_DICT_DIR"] = str(dict_path)
+    pyopenjtalk.OPEN_JTALK_DICT_DIR = str(dict_path).encode("utf-8")
+
+
 def safe_ja_g2p(text, kana=True, max_length=100):
+    """Convert Japanese text with OpenJTalk and fail on conversion errors."""
     if len(text) > max_length:
-        # 如果文本过长，分段处理
         parts = []
         for i in range(0, len(text), max_length):
-            part = text[i:i+max_length]
+            part = text[i : i + max_length]
             try:
                 converted = pyopenjtalk.g2p(part, kana=kana)
                 parts.append(converted)
-            except Exception:
-                parts.append(part)  # 如果转换失败，使用原文本
-        return ' '.join(parts)
-    else:
-        try:
-            return pyopenjtalk.g2p(text, kana=kana)
-        except Exception:
-            return text  # 如果转换失败，返回原文本
+            except Exception as exc:
+                raise RuntimeError(
+                    f"OpenJTalk failed to normalize Japanese text: {part[:80]!r}"
+                ) from exc
+        return " ".join(parts)
+
+    try:
+        return pyopenjtalk.g2p(text, kana=kana)
+    except Exception as exc:
+        raise RuntimeError(
+            f"OpenJTalk failed to normalize Japanese text: {text[:80]!r}"
+        ) from exc
 
 
-def normalize_text(srcfn, dstfn, kana=False):
-    with open(srcfn, "r") as f_read, open(dstfn, "w") as f_write:
+def normalize_text(
+    srcfn,
+    dstfn,
+    kana=False,
+    open_jtalk_dict=None,
+    input_format="id-text",
+):
+    """Normalize an utterance transcript file for ASR scoring."""
+    if kana:
+        configure_open_jtalk_dict(open_jtalk_dict)
+    if input_format not in {"id-text", "path-id-text"}:
+        raise ValueError(f"unsupported input format: {input_format}")
+
+    with (
+        open(srcfn, "r", encoding="utf-8") as f_read,
+        open(dstfn, "w", encoding="utf-8") as f_write,
+    ):
         all_lines = f_read.readlines()
-        for line in all_lines:
+        for line_number, line in enumerate(all_lines, start=1):
             line = line.strip()
-            line_arr = line.split(maxsplit=1)
-            if len(line_arr) < 1:
+            if not line:
                 continue
-            if len(line_arr) == 1:
-                line_arr.append("")
-            key = line_arr[0]
-            line_arr[1] = re.sub(r"=", " ", line_arr[1])
-            line_arr[1] = re.sub(r"\(", " ", line_arr[1])
-            line_arr[1] = re.sub(r"\)", " ", line_arr[1])
+
+            if input_format == "path-id-text":
+                fields = line.split(maxsplit=2)
+                if len(fields) < 2:
+                    raise ValueError(
+                        f"line {line_number} requires audio-path and utterance-id"
+                    )
+                key = fields[1]
+                text = fields[2] if len(fields) == 3 else ""
+            else:
+                fields = line.split(maxsplit=1)
+                key = fields[0]
+                text = fields[1] if len(fields) == 2 else ""
+
+            text = re.sub(r"=", " ", text)
+            text = re.sub(r"\(", " ", text)
+            text = re.sub(r"\)", " ", text)
             # From Chongjia Ni
             if kana:
-                line_arr[1] = safe_ja_g2p(line_arr[1], kana=True, max_length=100)
+                text = safe_ja_g2p(text, kana=True, max_length=100)
 
-            line_arr = f"{key}\t{line_arr[1]}".split()
+            line_arr = f"{key}\t{text}".split()
             conts = []
             language_bak = ""
             part = []
@@ -126,10 +175,49 @@ def normalize_text(srcfn, dstfn, kana=False):
                         out_part = zhconv.convert(out_part3, "zh-cn")
                     conts.append(out_part)
 
-            f_write.write("{0}\t{1}\n".format(key, " ".join(conts).strip()))
+            f_write.write("{}\t{}\n".format(key, " ".join(conts).strip()))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Normalize utterance-id/text files before ASR scoring."
+    )
+    parser.add_argument("srcfn", help="input file: utterance-id followed by text")
+    parser.add_argument("dstfn", help="normalized output file")
+    parser.add_argument(
+        "legacy_ja_norm",
+        nargs="?",
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--language",
+        choices=("auto", "ja"),
+        default="auto",
+        help="use OpenJTalk kana normalization for Japanese",
+    )
+    parser.add_argument(
+        "--open-jtalk-dict",
+        help="optional OpenJTalk dictionary directory containing sys.dic",
+    )
+    parser.add_argument(
+        "--input-format",
+        choices=("id-text", "path-id-text"),
+        default="id-text",
+        help="input columns: 'utterance-id text' or 'audio-path utterance-id text'",
+    )
+    args = parser.parse_args()
+
+    kana = args.language == "ja" or args.legacy_ja_norm is not None
+    if args.open_jtalk_dict and not kana:
+        parser.error("--open-jtalk-dict requires --language ja")
+    normalize_text(
+        args.srcfn,
+        args.dstfn,
+        kana=kana,
+        open_jtalk_dict=args.open_jtalk_dict,
+        input_format=args.input_format,
+    )
 
 
 if __name__ == "__main__":
-    srcfn = sys.argv[1]
-    dstfn = sys.argv[2]
-    normalize_text(srcfn, dstfn, True if len(sys.argv) > 3 else False)
+    main()

--- a/tools/whisper_mix_normalize.py
+++ b/tools/whisper_mix_normalize.py
@@ -2,7 +2,6 @@
 """Normalize ASR transcripts before WER/CER scoring."""
 
 import argparse
-import os
 import re
 from pathlib import Path
 
@@ -44,27 +43,32 @@ def is_number(s):
 
 
 def configure_open_jtalk_dict(dict_dir):
-    """Configure an explicit OpenJTalk system dictionary directory."""
+    """Create an OpenJTalk frontend for an explicit system dictionary."""
     if dict_dir is None:
-        return
+        return None
 
-    dict_path = Path(dict_dir).expanduser().resolve()
+    dict_path = Path(dict_dir).expanduser().absolute()
     if not (dict_path / "sys.dic").is_file():
         raise RuntimeError(f"OpenJTalk dictionary is missing sys.dic: {dict_path}")
 
-    # pyopenjtalk reads this value when its global frontend is initialized.
-    os.environ["OPEN_JTALK_DICT_DIR"] = str(dict_path)
-    pyopenjtalk.OPEN_JTALK_DICT_DIR = str(dict_path).encode("utf-8")
+    # Do not mutate OPEN_JTALK_DICT_DIR or _global_jtalk. The package caches its
+    # global frontend after the first g2p call, so changing the global path can
+    # silently leave a previously initialized dictionary in use.
+    return pyopenjtalk.OpenJTalk(dn_mecab=str(dict_path).encode("utf-8"))
 
 
-def safe_ja_g2p(text, kana=True, max_length=100):
+def safe_ja_g2p(text, kana=True, max_length=100, jtalk=None):
     """Convert Japanese text with OpenJTalk and fail on conversion errors."""
+    g2p_kwargs = {"kana": kana}
+    if jtalk is not None:
+        g2p_kwargs["jtalk"] = jtalk
+
     if len(text) > max_length:
         parts = []
         for i in range(0, len(text), max_length):
             part = text[i : i + max_length]
             try:
-                converted = pyopenjtalk.g2p(part, kana=kana)
+                converted = pyopenjtalk.g2p(part, **g2p_kwargs)
                 parts.append(converted)
             except Exception as exc:
                 raise RuntimeError(
@@ -73,7 +77,7 @@ def safe_ja_g2p(text, kana=True, max_length=100):
         return " ".join(parts)
 
     try:
-        return pyopenjtalk.g2p(text, kana=kana)
+        return pyopenjtalk.g2p(text, **g2p_kwargs)
     except Exception as exc:
         raise RuntimeError(
             f"OpenJTalk failed to normalize Japanese text: {text[:80]!r}"
@@ -88,8 +92,7 @@ def normalize_text(
     input_format="id-text",
 ):
     """Normalize an utterance transcript file for ASR scoring."""
-    if kana:
-        configure_open_jtalk_dict(open_jtalk_dict)
+    jtalk = configure_open_jtalk_dict(open_jtalk_dict) if kana else None
     if input_format not in {"id-text", "path-id-text"}:
         raise ValueError(f"unsupported input format: {input_format}")
 
@@ -121,7 +124,12 @@ def normalize_text(
             text = re.sub(r"\)", " ", text)
             # From Chongjia Ni
             if kana:
-                text = safe_ja_g2p(text, kana=True, max_length=100)
+                text = safe_ja_g2p(
+                    text,
+                    kana=True,
+                    max_length=100,
+                    jtalk=jtalk,
+                )
 
             line_arr = f"{key}\t{text}".split()
             conts = []

--- a/tools/whisper_mix_normalize.py
+++ b/tools/whisper_mix_normalize.py
@@ -59,16 +59,18 @@ def configure_open_jtalk_dict(dict_dir):
 
 def safe_ja_g2p(text, kana=True, max_length=100, jtalk=None):
     """Convert Japanese text with OpenJTalk and fail on conversion errors."""
-    g2p_kwargs = {"kana": kana}
-    if jtalk is not None:
-        g2p_kwargs["jtalk"] = jtalk
+
+    def convert(part):
+        if jtalk is not None:
+            return jtalk.g2p(part, kana=kana)
+        return pyopenjtalk.g2p(part, kana=kana)
 
     if len(text) > max_length:
         parts = []
         for i in range(0, len(text), max_length):
             part = text[i : i + max_length]
             try:
-                converted = pyopenjtalk.g2p(part, **g2p_kwargs)
+                converted = convert(part)
                 parts.append(converted)
             except Exception as exc:
                 raise RuntimeError(
@@ -77,7 +79,7 @@ def safe_ja_g2p(text, kana=True, max_length=100, jtalk=None):
         return " ".join(parts)
 
     try:
-        return pyopenjtalk.g2p(text, **g2p_kwargs)
+        return convert(text)
     except Exception as exc:
         raise RuntimeError(
             f"OpenJTalk failed to normalize Japanese text: {text[:80]!r}"


### PR DESCRIPTION
## Summary

- add a one-command Japanese CER workflow that converts reference and hypothesis text to katakana with OpenJTalk before running `compute-wer`
- support both `utterance-id text` and `audio-path utterance-id text` inputs, plus an explicit OpenJTalk 1.11 dictionary for reproducible benchmarks
- make Japanese normalization failures explicit instead of silently scoring unnormalized text
- document the workflow and add unit and real end-to-end coverage

## Testing

- `python -m pytest -q tests/test_japanese_cer.py` — 6 passed
- `python -m pytest -q tests --ignore=tests/test_checkpoint_ctc_guard.py --ignore=tests/test_realtime_ws_service.py` — 25 passed, 37 subtests passed
- `ruff check` and `ruff format --check` on changed Python files
- DSW Linux smoke test with the supplied `open_jtalk_dic_utf_8-1.11` and three-column inputs — normalized IDs/text correctly and produced 0.00% CER for equivalent readings