### PR TITLE
docs: link MOSS diarization deployment from Fun-ASR

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ pip install -r requirements.txt
   > The current ModelScope `FunAudioLLM/Fun-ASR-Nano-2512` checkpoint includes all 86 trained `ctc_decoder.*` / `ctc.*` tensors (`model.pt` SHA-256 `81fec8616083c69377f3ceef36aba3655660ee0ca69a5d4a1e9810cd340ca499`) and produces native CTC timestamps. The Hugging Face checkpoint at revision `272c57b82523ada6fd87095e955f8e29100979ab` is still the older text-only artifact (`model.pt` SHA-256 `55ae0d2fee369f0f11cce0795f6927934ad17cf11b278a7e56a51272074160bb`) with no CTC tensors. When this repository's current `model.py` is used with `funasr>=1.3.26`, incomplete checkpoints fail closed: transcription remains available, but `timestamps` are omitted instead of returning random 60 ms alignments. Use `hub="ms"` for checkpoint-native timestamps until the Hugging Face artifact and remote code are synchronized. See [issue #70](https://github.com/QwenAudio/Fun-ASR/issues/70) and [FunASR #3496](https://github.com/modelscope/FunASR/issues/3496).
 - [ ] Checkpoint-native speaker diarization
   > Fun-ASR-Nano and Fun-ASR-MLT-Nano do not emit speaker labels by themselves. Compose them in FunASR with the separate `fsmn-vad` and `cam++` models, as shown below.
+  > For one-pass anonymous diarization with transcription and timestamps, use the third-party OpenMOSS [MOSS-Transcribe-Diarize deployment guide](https://www.funasr.com/deploy/moss-transcribe-diarize.html). It is a separate model rather than a Fun-ASR-Nano checkpoint feature.
 - [x] Model training
 
 # Usage 🛠️

--- a/README_zh.md
+++ b/README_zh.md
@@ -72,6 +72,7 @@ pip install -r requirements.txt
   > 当前 ModelScope `FunAudioLLM/Fun-ASR-Nano-2512` checkpoint 已包含全部 86 个训练后的 `ctc_decoder.*` / `ctc.*` 张量（`model.pt` SHA-256：`81fec8616083c69377f3ceef36aba3655660ee0ca69a5d4a1e9810cd340ca499`），可以输出原生 CTC 时间戳。Hugging Face revision `272c57b82523ada6fd87095e955f8e29100979ab` 仍是旧的纯文本权重（`model.pt` SHA-256：`55ae0d2fee369f0f11cce0795f6927934ad17cf11b278a7e56a51272074160bb`），不含 CTC 张量。使用本仓库当前 `model.py` 与 `funasr>=1.3.26` 时，不完整 checkpoint 会安全关闭 CTC：文本转写继续可用，但不会再返回随机的 60 ms 时间戳。Hugging Face 权重和远程代码同步前，需要原生时间戳请使用 `hub="ms"`。详见 [issue #70](https://github.com/QwenAudio/Fun-ASR/issues/70) 与 [FunASR #3496](https://github.com/modelscope/FunASR/issues/3496)。
 - [ ] checkpoint 原生说话人分离
   > Fun-ASR-Nano 和 Fun-ASR-MLT-Nano 本身不输出说话人标签；需在 FunASR 中组合独立的 `fsmn-vad` 与 `cam++` 模型。
+  > 如需一次完成转写、时间戳和匿名说话人标签，可使用第三方 OpenMOSS 的 [MOSS-Transcribe-Diarize 部署指南](https://www.funasr.com/deploy/moss-transcribe-diarize.html)。它是独立模型，不是 Fun-ASR-Nano checkpoint 的原生能力。
 - [x] 支持模型训练
 
 # 用法 🛠️

--- a/tests/test_moss_ecosystem_docs.py
+++ b/tests/test_moss_ecosystem_docs.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MOSS_URL = "https://www.funasr.com/deploy/moss-transcribe-diarize.html"
+
+
+def test_readmes_distinguish_nano_from_one_pass_moss_diarization():
+    for name in ("README.md", "README_zh.md"):
+        text = (ROOT / name).read_text(encoding="utf-8")
+
+        assert "MOSS-Transcribe-Diarize" in text, name
+        assert MOSS_URL in text, name
+
+    assert "do not emit speaker labels by themselves" in (
+        ROOT / "README.md"
+    ).read_text(encoding="utf-8")
+    assert "本身不输出说话人标签" in (ROOT / "README_zh.md").read_text(
+        encoding="utf-8"
+    )


### PR DESCRIPTION
Adds a concise MOSS-Transcribe-Diarize route beside Fun-ASR-Nano speaker-diarization boundaries.

- keeps the distinction explicit: Nano uses the composed FSMN-VAD + CAM++ path; MOSS is a separate OpenMOSS model for one-pass anonymous diarization, transcription, and timestamps
- adds the live FunASR MOSS deployment link to English and Chinese READMEs
- adds a regression contract so both README links and the capability boundary remain aligned

Verification:
- python -m pytest -q tests/test_moss_ecosystem_docs.py tests/test_timestamp_documentation.py tests/test_canonical_qwenaudio_links.py (6 passed)
- git diff --check

Signed-off-by: LauraGPT <18321252+LauraGPT@users.noreply.github.com>