### PR TITLE
docs: align multilingual release highlights with 1.4.13

### DIFF
--- a/README_ja.md
+++ b/README_ja.md
@@ -2,7 +2,7 @@
 
 「[简体中文](README_zh.md)」|「[English](README.md)」|「日本語」
 
-> **FunASR 1.4.12:** audio compute が FP16 のときの Fun-ASR-Nano vLLM 出力を安定化します。Qwen3 decoder は BF16 を使用し、BF16 非対応 GPU では FP32 を使用します。`pip install -U "funasr==1.4.12"`。[Release ->](https://github.com/modelscope/FunASR/releases/tag/v1.4.12) · [Runtime v0.2.3 ->](https://github.com/modelscope/FunASR/releases/tag/runtime-llamacpp-v0.2.3)
+> **FunASR 1.4.13:** audio compute が FP16 のときの Fun-ASR-Nano vLLM 出力を安定化します。Qwen3 decoder は BF16 を使用し、BF16 非対応 GPU では FP32 を使用します。`pip install -U "funasr==1.4.13"`。[Release ->](https://github.com/modelscope/FunASR/releases/tag/v1.4.13) · [Runtime v0.2.3 ->](https://github.com/modelscope/FunASR/releases/tag/runtime-llamacpp-v0.2.3)
 
 > **MOSS-Transcribe-Diarize:** OpenMOSS の第三者モデルで、オフライン長時間転写、timestamp、匿名 speaker label を一度に処理します。FunASR service、Docker、Kubernetes、vLLM、SGLang、LocalAI、FunClip のデプロイパスを利用できます。[MOSS をデプロイ ->](https://www.funasr.com/deploy/moss-transcribe-diarize.html)
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -2,7 +2,7 @@
 
 「[简体中文](README_zh.md)」|「[English](README.md)」|「[日本語](README_ja.md)」|「한국어」
 
-> **FunASR 1.4.12:** audio compute가 FP16일 때 Fun-ASR-Nano vLLM 출력을 안정화합니다. Qwen3 decoder는 BF16을 사용하며 BF16 미지원 GPU에서는 FP32를 사용하세요. `pip install -U "funasr==1.4.12"`. [Release ->](https://github.com/modelscope/FunASR/releases/tag/v1.4.12) · [Runtime v0.2.3 ->](https://github.com/modelscope/FunASR/releases/tag/runtime-llamacpp-v0.2.3)
+> **FunASR 1.4.13:** audio compute가 FP16일 때 Fun-ASR-Nano vLLM 출력을 안정화합니다. Qwen3 decoder는 BF16을 사용하며 BF16 미지원 GPU에서는 FP32를 사용하세요. `pip install -U "funasr==1.4.13"`. [Release ->](https://github.com/modelscope/FunASR/releases/tag/v1.4.13) · [Runtime v0.2.3 ->](https://github.com/modelscope/FunASR/releases/tag/runtime-llamacpp-v0.2.3)
 
 > **MOSS-Transcribe-Diarize:** OpenMOSS의 서드파티 모델로 오프라인 장시간 전사, timestamp, 익명 speaker label을 한 번에 처리합니다. FunASR service, Docker, Kubernetes, vLLM, SGLang, LocalAI, FunClip 배포 경로를 사용할 수 있습니다. [MOSS 배포 ->](https://www.funasr.com/deploy/moss-transcribe-diarize.html)
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -36,7 +36,7 @@ Fun-ASR 是通义实验室推出的端到端语音识别模型家族，不同 ch
 
 # 最新动态 🔥
 
-- **FunASR 1.4.12** 在音频计算使用 FP16 时稳定 Fun-ASR-Nano 的 vLLM 输出：Qwen3 decoder 使用 BF16；不支持 BF16 的 GPU 请使用 FP32。安装命令：`pip install -U "funasr==1.4.12"`。[发布说明 ->](https://github.com/modelscope/FunASR/releases/tag/v1.4.12)
+- **FunASR 1.4.13** 在音频计算使用 FP16 时稳定 Fun-ASR-Nano 的 vLLM 输出：Qwen3 decoder 使用 BF16；不支持 BF16 的 GPU 请使用 FP32。安装命令：`pip install -U "funasr==1.4.13"`。[发布说明 ->](https://github.com/modelscope/FunASR/releases/tag/v1.4.13)
 - **MOSS-Transcribe-Diarize** 是 OpenMOSS 的第三方模型，可离线完成长音频转写、时间戳和匿名说话人标签；FunASR 已提供服务、Docker、Kubernetes、vLLM、SGLang、LocalAI 与 FunClip 部署路径。[部署 MOSS ->](https://www.funasr.com/deploy/moss-transcribe-diarize.html)
 - **工业部署** 覆盖实时 WebSocket 服务、原生 vLLM 批量/流式路径，以及已校验的 Linux、macOS、Windows llama.cpp / GGUF 包。[Runtime v0.2.3 ->](https://github.com/modelscope/FunASR/releases/tag/runtime-llamacpp-v0.2.3) · [vLLM 指南 ->](docs/vllm_guide_zh.md)
 - 2025/12: [Fun-ASR-Nano-2512](https://modelscope.cn/models/FunAudioLLM/Fun-ASR-Nano-2512) 上线，支持中文、英文、日文及中文方言和地域口音。31 语种识别请使用独立的 [Fun-ASR-MLT-Nano-2512](https://modelscope.cn/models/FunAudioLLM/Fun-ASR-MLT-Nano-2512) checkpoint。

--- a/tests/test_funasr_requirement.py
+++ b/tests/test_funasr_requirement.py
@@ -40,8 +40,8 @@ def test_docs_use_quoted_current_funasr_install_commands():
 
 def test_readmes_surface_current_release_and_deployment_paths():
     required = [
-        "funasr==1.4.12",
-        "https://github.com/modelscope/FunASR/releases/tag/v1.4.12",
+        "funasr==1.4.13",
+        "https://github.com/modelscope/FunASR/releases/tag/v1.4.13",
         "MOSS-Transcribe-Diarize",
         "https://www.funasr.com/deploy/moss-transcribe-diarize.html",
         "runtime-llamacpp-v0.2.3",


### PR DESCRIPTION
## Summary

- align the Chinese, Japanese, and Korean first-screen release highlights with the published FunASR 1.4.13 release
- keep the README release contract pinned to the current release, preventing one language from silently retaining an older install command

## Validation

- python -m pytest tests/test_funasr_requirement.py -q
- git diff --check

Signed and DCO-compliant.