### PR TITLE
docs: keep Fun-ASR updates concise

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ Online Experience:
 - **FunASR 1.4.13** stabilizes Fun-ASR-Nano vLLM output when audio compute uses FP16: the Qwen3 decoder uses BF16; use FP32 on GPUs without BF16 support. Install with `pip install -U "funasr==1.4.13"`. [Release ->](https://github.com/modelscope/FunASR/releases/tag/v1.4.13)
 - **MOSS-Transcribe-Diarize** is a third-party OpenMOSS model for offline long-form transcription, timestamps, and anonymous speaker labels, with FunASR service, Docker, Kubernetes, vLLM, SGLang, LocalAI, and FunClip deployment paths. [Deploy MOSS ->](https://www.funasr.com/deploy/moss-transcribe-diarize.html)
 - **Production deployment** covers realtime WebSocket serving, native vLLM batch/streaming paths, and verified llama.cpp / GGUF packages for Linux, macOS, and Windows. [Runtime v0.2.3 ->](https://github.com/modelscope/FunASR/releases/tag/runtime-llamacpp-v0.2.3) · [vLLM guide ->](docs/vllm_guide.md)
-- 2025/12: [Fun-ASR-Nano-2512](https://modelscope.cn/models/FunAudioLLM/Fun-ASR-Nano-2512) was released for Chinese, English, Japanese, and Chinese dialects and accents. For 31-language recognition, use the separate [Fun-ASR-MLT-Nano-2512](https://modelscope.cn/models/FunAudioLLM/Fun-ASR-MLT-Nano-2512) checkpoint.
-- 2024/7: [FunASR](https://github.com/modelscope/FunASR) is a fundamental speech recognition toolkit that offers a variety of features, including speech recognition (ASR), Voice Activity Detection (VAD), Punctuation Restoration, Language Models, Speaker Verification, Speaker Diarization and multi-talker ASR.
 
 # Core Features 🎯
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -39,8 +39,6 @@ Fun-ASR 是通义实验室推出的端到端语音识别模型家族，不同 ch
 - **FunASR 1.4.13** 在音频计算使用 FP16 时稳定 Fun-ASR-Nano 的 vLLM 输出：Qwen3 decoder 使用 BF16；不支持 BF16 的 GPU 请使用 FP32。安装命令：`pip install -U "funasr==1.4.13"`。[发布说明 ->](https://github.com/modelscope/FunASR/releases/tag/v1.4.13)
 - **MOSS-Transcribe-Diarize** 是 OpenMOSS 的第三方模型，可离线完成长音频转写、时间戳和匿名说话人标签；FunASR 已提供服务、Docker、Kubernetes、vLLM、SGLang、LocalAI 与 FunClip 部署路径。[部署 MOSS ->](https://www.funasr.com/deploy/moss-transcribe-diarize.html)
 - **工业部署** 覆盖实时 WebSocket 服务、原生 vLLM 批量/流式路径，以及已校验的 Linux、macOS、Windows llama.cpp / GGUF 包。[Runtime v0.2.3 ->](https://github.com/modelscope/FunASR/releases/tag/runtime-llamacpp-v0.2.3) · [vLLM 指南 ->](docs/vllm_guide_zh.md)
-- 2025/12: [Fun-ASR-Nano-2512](https://modelscope.cn/models/FunAudioLLM/Fun-ASR-Nano-2512) 上线，支持中文、英文、日文及中文方言和地域口音。31 语种识别请使用独立的 [Fun-ASR-MLT-Nano-2512](https://modelscope.cn/models/FunAudioLLM/Fun-ASR-MLT-Nano-2512) checkpoint。
-- 2024/7: [FunASR](https://github.com/modelscope/FunASR) 是一款功能全面的语音识别基础工具包，集成了多项核心功能，包括自动语音识别（ASR）、语音活动检测（VAD）、标点恢复、语言模型、说话人验证、说话人日志记录以及多说话人语音识别。
 
 # 核心特性 🎯
 

--- a/tests/test_funasr_requirement.py
+++ b/tests/test_funasr_requirement.py
@@ -54,6 +54,18 @@ def test_readmes_surface_current_release_and_deployment_paths():
         assert "funasr==1.3.27" not in text
 
 
+def test_whats_new_excludes_historical_release_notes():
+    sections = {
+        "README.md": ("# What's New", "# Core Features"),
+        "README_zh.md": ("# 最新动态", "# 核心特性"),
+    }
+    for path, (start, end) in sections.items():
+        text = (ROOT / path).read_text()
+        whats_new = text.split(start, 1)[1].split(end, 1)[0]
+        assert "2025/12:" not in whats_new
+        assert "2024/7:" not in whats_new
+
+
 def test_docs_relative_markdown_links_point_to_existing_files():
     link_pattern = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
     for relpath in DOCS:


### PR DESCRIPTION
Keeps the English and Chinese What's New sections focused on the current release, MOSS integration, and production deployment paths. Adds a regression test that prevents historical 2025/2024 release notes from returning to those sections.

Tests:
- python -m pytest tests/test_funasr_requirement.py -q
- git diff --check

Signed-off-by: LauraGPT <18321252+LauraGPT@users.noreply.github.com>