### PR TITLE
feat(llama.cpp): llama-funasr-cli --stream realtime mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ dist/
 build/
 .eggs/
 *.tar.gz
+
+# regression models (downloaded, not committed)
+runtime/llama.cpp/tests/models/

--- a/runtime/llama.cpp/README.md
+++ b/runtime/llama.cpp/README.md
@@ -114,6 +114,21 @@ build/bin/llama-funasr-cli --enc funasr-encoder.gguf -m qwen3-0.6b-q8_0.gguf \
 of the PyTorch front end) and decodes each speech segment — closing the fixed-window gap
 (full-184 micro-CER **8.30**, vs 9.5 % with `--chunk 15`). See [BENCHMARKS.md](BENCHMARKS.md).
 
+**Realtime streaming (`--stream`, mirrors `serve_realtime_ws.py`):**
+```bash
+cat audio.pcm | build/bin/llama-funasr-cli \
+    --enc funasr-encoder.gguf -m qwen3-0.6b-q8_0.gguf --vad fsmn-vad.gguf --stream
+```
+stdin takes raw 16 kHz mono s16le PCM; the encoder/LLM/VAD load once and stay resident.
+stdout is a line protocol: `LOCKED <text>` when the streaming VAD confirms a segment
+(irreversible, decoded once), `PARTIAL <text>` refreshes of the in-progress segment,
+`DONE` after EOF flushes the trailing speech. Cadence and budgets follow the python
+`RealtimeASRSession` (first decode at 480 ms, then every 960 ms of audio; 15 s partial
+window cap; 200/512-token budgets for partial/locked decodes; DynamicStreamingVAD
+silence schedule). Segment boundaries align with `DynamicStreamingVAD` (see
+`tests/align_streaming_vad.py`), and `--lang <language>` maps to the
+`语音转写成<language>：` prompt variant.
+
 ## Models & sizes
 
 | file | dtype | size |

--- a/runtime/llama.cpp/funasr-cli/funasr-cli.cpp
+++ b/runtime/llama.cpp/funasr-cli/funasr-cli.cpp
@@ -7,6 +7,13 @@
 // This is the whisper.cpp-style single-binary path: no Python at runtime.
 //
 //   funasr-cli --enc funasr-encoder.gguf -m qwen3-0.6b.gguf -a audio.wav
+//
+// Streaming (--stream): 16 kHz s16le mono PCM on stdin, models load once, emits
+//   LOCKED <text>   DynamicStreamingVAD-confirmed segment (committed, like python)
+//   PARTIAL <text>  unstable transcript of the in-progress segment (or empty when it ends)
+//   DONE            after stdin EOF + trailing-segment flush
+// Thresholds/protocol mirror serve_realtime_ws.py (RealtimeASRSession): 480ms first
+// decode, 960ms cadence, 15s partial window cap, 200/512 token budgets for partial/locked.
 
 #include "ggml.h"
 #include "ggml-cpu.h"
@@ -166,9 +173,224 @@ static int decode_batch(llama_context*ctx,int n,llama_token*tok,float*embd,int n
     int r=llama_decode(ctx,b); n_past+=n; return r;
 }
 
+// ---- encoder + LLM bundle, loaded once, reused per decode window ----
+struct asr_decoder {
+    enc_model em;
+    llama_model* model=nullptr;
+    const llama_vocab* vocab=nullptr;
+    llama_context* ctx=nullptr;
+    llama_sampler* smpl=nullptr;
+    std::vector<llama_token> pre, suf;
+};
+static void free_decoder(asr_decoder&d){
+    if(d.smpl) llama_sampler_free(d.smpl);
+    if(d.ctx) llama_free(d.ctx);
+    if(d.model) llama_model_free(d.model);
+    if(d.em.ctx_w) ggml_free(d.em.ctx_w);
+    d = asr_decoder{};
+}
+static bool load_decoder(const char*enc_path, const char*llm_path, float rep,
+                         const std::string&lang, asr_decoder&d){
+    if(!load_enc(enc_path,d.em)) return false;
+    ggml_backend_load_all();
+    llama_model_params mp=llama_model_default_params(); mp.n_gpu_layers=0;
+    d.model=llama_model_load_from_file(llm_path,mp); if(!d.model) return false;
+    d.vocab=llama_model_get_vocab(d.model);
+    llama_context_params cp=llama_context_default_params();
+    cp.n_ctx=2048; cp.n_batch=2048; cp.n_ubatch=2048;
+    d.ctx=llama_init_from_model(d.model,cp);
+    if(!d.ctx){fprintf(stderr,"failed to create llama context\n");return false;}
+    auto sp=llama_sampler_chain_default_params(); d.smpl=llama_sampler_chain_init(sp);
+    if(rep!=1.0f) llama_sampler_chain_add(d.smpl,llama_sampler_init_penalties(256,rep,0.0f,0.0f));
+    llama_sampler_chain_add(d.smpl,llama_sampler_init_greedy());
+    // prompt mirrors FunASRNano.get_prompt(): 语音转写：" / 语音转写成<lang>："
+    std::string prefix="<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\n语音转写";
+    if(!lang.empty()) prefix+="成"+lang;
+    prefix+="：";
+    const char*suffix="<|im_end|>\n<|im_start|>assistant\n";
+    auto tokenize=[&](const std::string&s){int n=-llama_tokenize(d.vocab,s.c_str(),s.size(),nullptr,0,false,true);
+        std::vector<llama_token> v(n); llama_tokenize(d.vocab,s.c_str(),s.size(),v.data(),n,false,true); return v;};
+    d.pre=tokenize(prefix); d.suf=tokenize(suffix);
+    return true;
+}
+// Decode one 16k-mono window (seconds*16000 samples, [-1,1]) into text.
+static std::string asr_decode_window(asr_decoder&d, const float*pcm, size_t n, int npred){
+    std::vector<float> seg(pcm, pcm+n);
+    int T=0; auto fbank=compute_fbank(seg,T);
+    int D=0; auto adp=run_encoder(d.em,fbank,T,560,D);
+    int ol=1+(T-3+2)/2; ol=1+(ol-3+2)/2; int n_aud=(ol-1)/2+1;
+
+    llama_memory_clear(llama_get_memory(d.ctx), true);  // fresh context per chunk
+    int n_past=0;
+    decode_batch(d.ctx,d.pre.size(),d.pre.data(),nullptr,0,n_past,false);
+    decode_batch(d.ctx,n_aud,nullptr,adp.data(),D,n_past,false);
+    decode_batch(d.ctx,d.suf.size(),d.suf.data(),nullptr,0,n_past,true);
+    std::string out;
+    llama_token tk=llama_sampler_sample(d.smpl,d.ctx,-1);
+    for(int i=0;i<npred;i++){
+        if(llama_vocab_is_eog(d.vocab,tk))break;
+        char buf[256]; int k=llama_token_to_piece(d.vocab,tk,buf,sizeof(buf),0,true);
+        if(k>0) out.append(buf,k);
+        decode_batch(d.ctx,1,&tk,nullptr,0,n_past,true);
+        tk=llama_sampler_sample(d.smpl,d.ctx,-1);
+    }
+    return out;
+}
+
+// ---- text cleanup, mirroring serve_realtime_ws.py ----
+// _clean_asr_text(): strip <tags>, [brackets], a few artifact chars/tokens, collapse spaces.
+static std::string clean_asr_text(const std::string& in){
+    std::string s; s.reserve(in.size());
+    for(size_t i=0;i<in.size();){
+        char c=in[i];
+        if(c=='<'){ size_t e=in.find('>',i); if(e!=std::string::npos){ i=e+1; continue; } }
+        if(c=='['){ size_t e=in.find(']',i); if(e!=std::string::npos){ i=e+1; continue; } }
+        if(c==']'||c=='&'||c=='|'){ i++; continue; }
+        // full-width artifacts Ｏ(EF BC AF) ＆(EF BC 86) ｜(EF BD 9C)
+        if(i+2<in.size() && (unsigned char)in[i]==0xEF &&
+           (((unsigned char)in[i+1]==0xBC && ((unsigned char)in[i+2]==0xAF || (unsigned char)in[i+2]==0x86)) ||
+            ((unsigned char)in[i+1]==0xBD && (unsigned char)in[i+2]==0x9C))){ i+=3; continue; }
+        s+=c; i++;
+    }
+    auto erase_all=[&](const char*sub){ size_t p; while((p=s.find(sub))!=std::string::npos) s.erase(p,strlen(sub)); };
+    erase_all("/sil"); erase_all("endofbreak"); erase_all("FFFF");
+    // collapse whitespace + trim
+    std::string t; t.reserve(s.size());
+    bool ws=false;
+    for(char c:s){ if(c==' '||c=='\t'||c=='\n'||c=='\r'||c=='\f'||c=='\v'){ ws=true; continue; }
+        if(ws && !t.empty()) t+=' '; ws=false; t+=c; }
+    return t;
+}
+// detect_and_fix_hallucination(): repeated word/char-ngram >= max_occurrences -> truncate
+// after the 2nd occurrence in the original text. Returns {text, hallucinated}.
+static std::pair<std::string,bool> fix_hallucination(const std::string& text, int max_ngram=12, int max_occ=3){
+    if(text.empty() || (int)text.size() < max_ngram*2) return {text,false};
+    std::string cleaned; cleaned.reserve(text.size());   // roughly \p{P} removal (ASCII punct)
+    for(char c:text) if(!ispunct((unsigned char)c)) cleaned+=c;
+    auto has_nondigit=[&](const std::string&w){ for(char c:w) if(!isdigit((unsigned char)c)) return true; return false; };
+    std::string repeated;
+    // word level: same whitespace-separated token repeated >= max_occ times consecutively
+    {
+        std::vector<std::string> ws; size_t b=0;
+        for(size_t i=0;i<=cleaned.size();i++) if(i==cleaned.size()||cleaned[i]==' '||cleaned[i]=='\t'){
+            if(i>b)ws.push_back(cleaned.substr(b,i-b)); b=i+1; }
+        for(size_t i=0,j;i<ws.size();i++){ for(j=i+1;j<=ws.size();j++){
+            if(j<ws.size()){
+                std::string a=ws[i],c=ws[j]; for(auto&x:a)x=tolower(x); for(auto&x:c)x=tolower(x);
+                if(a==c)continue;
+            }
+            // run [i,j) of identical tokens ended; python: {max_occurrences-1,} repeats
+            // after the first -> trigger at >= max_occurrences total occurrences
+            if(j-i>=(size_t)max_occ && has_nondigit(ws[i])){ repeated=ws[i]; break; }
+            i=j-1; break;
+        } if(!repeated.empty())break; }
+    }
+    // char-ngram level: L-length block repeated >= max_occ times inside a whitespace-free run
+    for(int L=1; repeated.empty() && L<max_ngram; L++){
+        for(size_t r0=0; r0<cleaned.size() && repeated.empty();){
+            size_t r1=cleaned.find_first_of(" \t",r0); if(r1==std::string::npos)r1=cleaned.size();
+            for(size_t i=r0; i+ (size_t)max_occ*L <= r1; i++){
+                bool ok=true, digit_only=true;
+                for(int k=1;k<max_occ;k++) if(cleaned.compare(i,L,cleaned,i+(size_t)k*L,L)!=0){ok=false;break;}
+                if(ok){ for(int k=0;k<L;k++) if(!isdigit((unsigned char)cleaned[i+k])) digit_only=false;
+                    if(!digit_only) repeated=cleaned.substr(i,L); break; }
+            }
+            r0=r1+1;
+        }
+    }
+    if(repeated.empty()) return {text,false};
+    size_t p1=text.find(repeated);
+    if(p1!=std::string::npos){
+        size_t p2=text.find(repeated,p1+repeated.size());
+        if(p2!=std::string::npos) return {text.substr(0,p2+repeated.size()),true};
+    }
+    return {text.substr(0,text.size()/2),true};
+}
+
+// ---- streaming mode (--stream): 16k s16le PCM on stdin -> LOCKED/PARTIAL/DONE on stdout ----
+// Protocol and thresholds mirror serve_realtime_ws.py's RealtimeASRSession:
+//   chunk_ms=960 cadence (first decode at 480ms), partial window capped at 15s of the
+//   in-progress VAD segment, locked segments = DynamicStreamingVAD-confirmed segments.
+static void emit_line(const char*tag, const std::string&text){
+    std::string t=text;
+    for(auto&c:t) if(c=='\n'||c=='\r') c=' ';
+    if(t.empty()) printf("%s\n",tag);          // DONE, and empty PARTIAL (partial reset)
+    else printf("%s %s\n",tag,t.c_str());
+    fflush(stdout);
+}
+static int run_stream(asr_decoder&d, const std::string&vad_path, int vad_maxseg){
+    const size_t SR=16000;
+    const size_t ANALYSIS=960;            // 60ms VAD/partial analysis quantum
+    const size_t FIRST_CHUNK=SR*480/1000, CHUNK=SR*960/1000;   // decode cadence
+    const size_t PARTIAL_WIN=SR*15;       // 15s partial window cap
+    const size_t MIN_PARTIAL=CHUNK/2, MIN_LOCKED=1600;         // python: chunk//2 / 100ms
+    funasr_vad_stream*vs=funasr_vad_stream_open(vad_path.c_str(),vad_maxseg);
+    std::vector<float> wav;               // full session audio (64KB/s, fine)
+    size_t analyzed=0, last_decode=0; bool first_done=false;
+    std::string last_partial;
+    for(;;){
+        unsigned char blk[16384]; size_t got=fread(blk,1,sizeof blk,stdin);
+        bool eof=(got<sizeof blk);
+        // s16le -> f32 (carry an odd byte across reads)
+        static unsigned char carry=0; static bool have_carry=false;
+        size_t i0=0;
+        if(have_carry && got>=1){ short v=(short)((blk[0]<<8)|carry); wav.push_back(v/32768.0f); have_carry=false; i0=1; }
+        size_t n=(got-i0)/2; size_t base=wav.size(); wav.resize(base+n);
+        for(size_t i=0;i<n;i++){ unsigned char b0=blk[i0+2*i], b1=blk[i0+2*i+1];
+            wav[base+i]=((short)((b1<<8)|b0))/32768.0f; }
+        if(i0+2*n<got){ carry=blk[i0+2*n]; have_carry=true; }
+        // quantized analysis checkpoints: VAD emission + locked/partial decode decisions
+        // depend only on buffer contents at 60ms-quantized positions, not on pipe read size.
+        while(analyzed+ANALYSIS<=wav.size() || (eof && analyzed<wav.size())){
+            size_t prev=analyzed;
+            analyzed=std::min(analyzed+ANALYSIS, wav.size());
+            std::vector<std::pair<int,int>> new_segs;
+            if(!funasr_vad_stream_feed(vs,wav.data()+prev,analyzed-prev,new_segs)){fprintf(stderr,"vad failed\n");funasr_vad_stream_close(vs);return 1;}
+            for(auto&s:new_segs){                       // DynamicStreamingVAD-confirmed segment -> LOCKED
+                size_t s0=(size_t)((int64_t)s.first*SR/1000), s1=(size_t)((int64_t)s.second*SR/1000);
+                if(s1>analyzed)s1=analyzed;
+                if(s1<=s0||s1-s0<MIN_LOCKED)continue;
+                std::string text=clean_asr_text(asr_decode_window(d,wav.data()+s0,s1-s0,512));
+                if(text.empty())continue;
+                fprintf(stderr,"[stream] locked [%d,%dms] \"%s\"\n",s.first,s.second,text.c_str());
+                emit_line("LOCKED",text);
+                last_partial.clear();
+            }
+            // RealtimeASRSession.decode() emulation for the in-progress segment
+            if(analyzed<CHUNK)continue;
+            if(vs->in_speech_start_ms<0){ last_decode=analyzed;
+                if(!last_partial.empty()){ emit_line("PARTIAL",""); last_partial.clear(); }
+                continue; }
+            size_t threshold=first_done?CHUNK:FIRST_CHUNK;
+            if(analyzed-last_decode<threshold)continue;
+            size_t start=(size_t)((int64_t)vs->in_speech_start_ms*SR/1000);
+            if(start+PARTIAL_WIN<analyzed)start=analyzed-PARTIAL_WIN;   // cap partial window to 15s
+            if(analyzed-start<MIN_PARTIAL)continue;
+            std::string text=clean_asr_text(asr_decode_window(d,wav.data()+start,analyzed-start,200));
+            auto fixed=fix_hallucination(text); text=fixed.first;
+            last_decode=analyzed;
+            if(text!=last_partial){ emit_line("PARTIAL",text); last_partial=text; }
+            if(!text.empty()&&!first_done)first_done=true;
+        }
+        if(eof)break;
+    }
+    // STOP: force-decode any trailing in-progress segment (python decode(is_final=True))
+    if(vs->in_speech_start_ms>=0){
+        size_t s0=(size_t)((int64_t)vs->in_speech_start_ms*SR/1000);
+        if(wav.size()>s0&&wav.size()-s0>=MIN_LOCKED){
+            std::string text=clean_asr_text(asr_decode_window(d,wav.data()+s0,wav.size()-s0,512));
+            if(!text.empty()){ fprintf(stderr,"[stream] locked [%d,%zums] \"%s\"\n",vs->in_speech_start_ms,
+                wav.size()*1000/SR,text.c_str()); emit_line("LOCKED",text); }
+        }
+    }
+    emit_line("DONE","");
+    funasr_vad_stream_close(vs);
+    return 0;
+}
+
 int main(int argc,char**argv){
-    std::string enc_path,llm_path,wav_path,vad_path; int npred=512; double chunk_sec=0; float rep=1.0f;
-    int vad_maxseg=30000;
+    std::string enc_path,llm_path,wav_path,vad_path,lang; int npred=512; double chunk_sec=0; float rep=1.0f;
+    int vad_maxseg=30000; bool stream=false;
     for(int i=1;i<argc;i++){
         if(!strcmp(argv[i],"--enc")&&i+1<argc)enc_path=argv[++i];
         else if(!strcmp(argv[i],"-m")&&i+1<argc)llm_path=argv[++i];
@@ -178,32 +400,27 @@ int main(int argc,char**argv){
         else if(!strcmp(argv[i],"--vad")&&i+1<argc)vad_path=argv[++i];
         else if(!strcmp(argv[i],"--vad-maxseg")&&i+1<argc)vad_maxseg=atoi(argv[++i]);
         else if(!strcmp(argv[i],"--rep")&&i+1<argc)rep=atof(argv[++i]);
-        else {fprintf(stderr,"usage: %s --enc enc.gguf -m llm.gguf -a audio.wav [-n npred] [--chunk sec] [--vad fsmn-vad.gguf [--vad-maxseg ms]]\n",argv[0]);return 1;}
+        else if(!strcmp(argv[i],"--lang")&&i+1<argc)lang=argv[++i];
+        else if(!strcmp(argv[i],"--stream"))stream=true;
+        else {fprintf(stderr,"usage: %s --enc enc.gguf -m llm.gguf (-a audio.wav | --stream) [-n npred] [--chunk sec] [--vad fsmn-vad.gguf [--vad-maxseg ms]] [--lang language]\n",argv[0]);return 1;}
     }
-    if(enc_path.empty()||llm_path.empty()||wav_path.empty()){fprintf(stderr,"missing args\n");return 1;}
+    if(enc_path.empty()||llm_path.empty()||(!stream&&wav_path.empty())){fprintf(stderr,"missing args\n");return 1;}
+    if(stream&&vad_path.empty()){fprintf(stderr,"--stream requires --vad fsmn-vad.gguf\n");return 1;}
 
     std::vector<float> wav;
-    if(!funasr_load_audio_16k_mono(wav_path.c_str(),wav)){fprintf(stderr,"failed to read audio\n");return 1;}
+    if(!stream){
+        if(!funasr_load_audio_16k_mono(wav_path.c_str(),wav)){fprintf(stderr,"failed to read audio\n");return 1;}
+    }
     int64_t t0=ggml_time_us();
 
-    enc_model em; if(!load_enc(enc_path.c_str(),em))return 1;
-    ggml_backend_load_all();
-    llama_model_params mp=llama_model_default_params(); mp.n_gpu_layers=0;
-    llama_model*model=llama_model_load_from_file(llm_path.c_str(),mp); if(!model)return 1;
-    const llama_vocab*vocab=llama_model_get_vocab(model);
-    llama_context_params cp=llama_context_default_params();
-    cp.n_ctx=2048; cp.n_batch=2048; cp.n_ubatch=2048;
-    llama_context*ctx=llama_init_from_model(model,cp);
-    if(!ctx){fprintf(stderr,"failed to create llama context\n");llama_model_free(model);return 1;}
-    auto sp=llama_sampler_chain_default_params(); llama_sampler*smpl=llama_sampler_chain_init(sp);
-    if(rep!=1.0f) llama_sampler_chain_add(smpl,llama_sampler_init_penalties(256,rep,0.0f,0.0f));
-    llama_sampler_chain_add(smpl,llama_sampler_init_greedy());
+    asr_decoder d;
+    if(!load_decoder(enc_path.c_str(),llm_path.c_str(),rep,lang,d)){free_decoder(d);return 1;}
 
-    const char*prefix="<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\n语音转写：";
-    const char*suffix="<|im_end|>\n<|im_start|>assistant\n";
-    auto tokenize=[&](const char*s){int n=-llama_tokenize(vocab,s,strlen(s),nullptr,0,false,true);
-        std::vector<llama_token> v(n); llama_tokenize(vocab,s,strlen(s),v.data(),n,false,true); return v;};
-    auto pre=tokenize(prefix); auto suf=tokenize(suffix);
+    if(stream){
+        int rc=run_stream(d,vad_path,vad_maxseg);
+        free_decoder(d);
+        return rc;
+    }
 
     // Build the list of [offset,len] windows to transcribe (in samples).
     //   --vad : FSMN-VAD speech segments (single-binary front end, replaces fixed chunking)
@@ -211,7 +428,7 @@ int main(int argc,char**argv){
     std::vector<std::pair<int,int>> wins;   // {sample offset, sample len}
     if(!vad_path.empty()){
         std::vector<std::pair<int,int>> segs; // ms
-        if(!funasr_vad_segments(vad_path,wav,vad_maxseg,segs)){fprintf(stderr,"vad failed\n");return 1;}
+        if(!funasr_vad_segments(vad_path,wav,vad_maxseg,segs)){fprintf(stderr,"vad failed\n");free_decoder(d);return 1;}
         for(auto&s:segs){ int off=(int)((int64_t)s.first*16000/1000), end=(int)((int64_t)s.second*16000/1000);
             if(end>(int)wav.size())end=wav.size(); if(end-off>0) wins.push_back({off,end-off}); }
         fprintf(stderr,"[vad] %zu segments\n",wins.size());
@@ -223,29 +440,11 @@ int main(int argc,char**argv){
     for (auto& w : wins) {
         int off = w.first, len = w.second;
         if (len < WINLEN) continue;                    // too short for one frame
-        std::vector<float> seg(wav.begin()+off, wav.begin()+off+len);
-        int T=0; auto fbank=compute_fbank(seg,T);
-        int D=0; auto adp=run_encoder(em,fbank,T,560,D);
-        int ol=1+(T-3+2)/2; ol=1+(ol-3+2)/2; int n_aud=(ol-1)/2+1;
-
-        llama_memory_clear(llama_get_memory(ctx), true);  // fresh context per chunk
-        int n_past=0;
-        decode_batch(ctx,pre.size(),pre.data(),nullptr,0,n_past,false);
-        decode_batch(ctx,n_aud,nullptr,adp.data(),D,n_past,false);
-        decode_batch(ctx,suf.size(),suf.data(),nullptr,0,n_past,true);
-        llama_token tk=llama_sampler_sample(smpl,ctx,-1);
-        for(int i=0;i<npred;i++){
-            if(llama_vocab_is_eog(vocab,tk))break;
-            char buf[256]; int k=llama_token_to_piece(vocab,tk,buf,sizeof(buf),0,true);
-            if(k>0) full.append(buf,k);
-            decode_batch(ctx,1,&tk,nullptr,0,n_past,true);
-            tk=llama_sampler_sample(smpl,ctx,-1);
-        }
+        full += asr_decode_window(d, wav.data()+off, len, npred);
     }
     printf("%s\n", full.c_str());
     int64_t t2=ggml_time_us();
     fprintf(stderr,"[done] %.2fs ; chunk=%.0fs\n",(t2-t0)/1e6, chunk_sec);
-    llama_sampler_free(smpl); llama_free(ctx); llama_model_free(model);
-    if(em.ctx_w) ggml_free(em.ctx_w);
+    free_decoder(d);
     return 0;
 }

--- a/runtime/llama.cpp/funasr-common/funasr_vad.h
+++ b/runtime/llama.cpp/funasr-common/funasr_vad.h
@@ -1,8 +1,11 @@
 // funasr_vad.h — single-header FSMN-VAD for the funasr ggml runtime.
-// Exposes funasr_vad_segments(): 16k mono wav -> speech segments [start_ms,end_ms].
+// Offline: funasr_vad_segments(): 16k mono wav -> speech segments [start_ms,end_ms].
+// Streaming: funasr_vad_stream_open/feed/close — incremental, irreversible segment
+// emission with the FunASR DynamicStreamingVAD schedule (serve_realtime_ws.py).
 // Front end (80-mel fbank + LFR m5n1 + CMVN) and FSMN encoder validated bit-exact vs
-// PyTorch fsmn-vad; the host state machine reproduces E2EVadModel (DEFAULT_SILENCE_SCHEDULE,
-// chunk-stepped) to within 1 frame (10ms) of fsmn-vad.generate on the 184-clip set.
+// PyTorch fsmn-vad; the host state machine reproduces E2EVadModel (chunk-stepped
+// classic schedule offline, DynamicStreamingVAD DEFAULT_SILENCE_SCHEDULE when streaming)
+// to within 1 frame (10ms) of fsmn-vad.generate on the 184-clip set.
 #pragma once
 #include "ggml.h"
 #include "ggml-cpu.h"
@@ -42,120 +45,281 @@ static std::vector<std::vector<float>> fbank80(std::vector<float> wav){
     for(int m=0;m<NMEL;m++){float e=0;for(int k=0;k<NB;k++)if(fb[m][k]>0)e+=fb[m][k]*(re[k]*re[k]+im[k]*im[k]);feat[t][m]=logf(e>fl?e:fl);}}
   return feat;
 }
-static std::vector<float> lfr(const std::vector<std::vector<float>>&feat,int m,int n,int&T_out){
+// LFR over a window of features with explicit global-edge handling.
+// Frames are stacked [i - (m-1)/2 .. i + m/2], clamped to [0, T-1] by edge replication,
+// matching the padding of the original batch lfr() below.
+static std::vector<std::vector<float>> lfr(const std::vector<std::vector<float>>&feat,int m,int n,int&T_out){
   int T=feat.size(); if(T<1){T_out=0;return {};}     // empty (audio shorter than one frame)
   int D=NMEL,pad=(m-1)/2; int Tl=(T+n-1)/n;
   std::vector<std::vector<float>> pf; pf.reserve(T+pad+m);
   for(int i=0;i<pad;i++)pf.push_back(feat[0]);
   for(int t=0;t<T;t++)pf.push_back(feat[t]);
   while((int)pf.size()<(Tl-1)*n+m)pf.push_back(feat[T-1]);
-  std::vector<float> out((size_t)Tl*m*D);
-  for(int i=0;i<Tl;i++)for(int j=0;j<m;j++)memcpy(&out[((size_t)i*m+j)*D],pf[i*n+j].data(),D*sizeof(float));
-  T_out=Tl; return out;
+  std::vector<float> flat((size_t)Tl*m*D);
+  for(int i=0;i<Tl;i++)for(int j=0;j<m;j++)memcpy(&flat[((size_t)i*m+j)*D],pf[i*n+j].data(),D*sizeof(float));
+  T_out=Tl;
+  // keep the historical [T x m*D] layout via re-wrap so callers stay unchanged
+  std::vector<std::vector<float>> rows(Tl,std::vector<float>(m*D));
+  for(int i=0;i<Tl;i++)memcpy(rows[i].data(),&flat[(size_t)i*m*D],(size_t)m*D*sizeof(float));
+  return rows;
 }
 struct vad{ggml_context*ctx=nullptr;std::map<std::string,ggml_tensor*>t;
   ggml_tensor*g(const std::string&n){auto it=t.find(n);if(it==t.end()){fprintf(stderr,"vad: missing %s\n",n.c_str());return nullptr;}return it->second;}};
 static ggml_tensor* lin(ggml_context*c,ggml_tensor*w,ggml_tensor*b,ggml_tensor*x){auto y=ggml_mul_mat(c,w,x);return b?ggml_add(c,y,b):y;}
-} // namespace funasr_vad_impl
 
-// Run FSMN-VAD on a 16k mono float waveform; fills segs with [start_ms,end_ms] speech spans.
-// max_seg_ms caps a single segment (e.g. 30000); pass <=0 to use 60000 (model default).
-inline bool funasr_vad_segments(const std::string& gguf_path, const std::vector<float>& wav,
-                                int max_seg_ms, std::vector<std::pair<int,int>>& segs, int nthreads=8){
-  using namespace funasr_vad_impl;
-  segs.clear();
-  vad m; gguf_init_params ip={false,&m.ctx}; gguf_context*gg=gguf_init_from_file(gguf_path.c_str(),ip);
-  if(!gg){fprintf(stderr,"vad: cannot load %s\n",gguf_path.c_str());return false;}
-  auto rd=[&](const char*k,int d){int i=gguf_find_key(gg,k);return i<0?d:(int)gguf_get_val_u32(gg,i);};
-  int idim=rd("vad.input_dim",400),pd=rd("vad.proj_dim",128),nl=rd("vad.fsmn_layers",4),lorder=rd("vad.lorder",20),
-      od=rd("vad.output_dim",248),lm=rd("vad.lfr_m",5),ln=rd("vad.lfr_n",1);
-  for(int i=0;i<gguf_get_n_tensors(gg);i++){const char*nm=gguf_get_tensor_name(gg,i);m.t[nm]=ggml_get_tensor(m.ctx,nm);}
-  gguf_free(gg);
-
-  // fail fast (not segfault) if the GGUF is missing tensors the graph dereferences
-  auto need=[&](const std::string&n){ return m.g(n)!=nullptr; };
-  bool ok_t = need("cmvn.shift")&&need("cmvn.scale")&&need("encoder.in_linear1.linear.weight")
-            &&need("encoder.in_linear2.linear.weight")&&need("encoder.out_linear1.linear.weight")
-            &&need("encoder.out_linear2.linear.weight");
-  for(int i=0;i<nl&&ok_t;i++){std::string p="encoder.fsmn."+std::to_string(i)+".";
-    ok_t=need(p+"linear.linear.weight")&&need(p+"fsmn_block.conv_left.weight")&&need(p+"affine.linear.weight");}
-  if(!ok_t){fprintf(stderr,"vad: gguf missing required tensors\n"); if(m.ctx)ggml_free(m.ctx); return false;}
-
-  auto feat=fbank80(wav); int T=0; auto feats=lfr(feat,lm,ln,T);   // [T,400]
-  if(T<1){if(m.ctx)ggml_free(m.ctx);return true;}                  // too short -> no speech
-  float*shift=(float*)m.g("cmvn.shift")->data,*scale=(float*)m.g("cmvn.scale")->data;
-  for(int t=0;t<T;t++)for(int d=0;d<idim;d++)feats[(size_t)t*idim+d]=(feats[(size_t)t*idim+d]+shift[d])*scale[d];
-
+// ---- model handle ----
+struct vad_model{
+  vad m; gguf_context*gg=nullptr;
+  int idim=400,pd=128,nl=4,lorder=20,od=248,lm=5,ln=1;
+  bool ok=false;
+};
+static bool funasr_vad_load(const std::string& gguf_path, vad_model& vm){
+  gguf_init_params ip={false,&vm.m.ctx}; vm.gg=gguf_init_from_file(gguf_path.c_str(),ip);
+  if(!vm.gg){fprintf(stderr,"vad: cannot load %s\n",gguf_path.c_str());return false;}
+  auto rd=[&](const char*k,int d){int i=gguf_find_key(vm.gg,k);return i<0?d:(int)gguf_get_val_u32(vm.gg,i);};
+  vm.idim=rd("vad.input_dim",400);vm.pd=rd("vad.proj_dim",128);vm.nl=rd("vad.fsmn_layers",4);
+  vm.lorder=rd("vad.lorder",20);vm.od=rd("vad.output_dim",248);vm.lm=rd("vad.lfr_m",5);vm.ln=rd("vad.lfr_n",1);
+  for(int i=0;i<gguf_get_n_tensors(vm.gg);i++){const char*nm=gguf_get_tensor_name(vm.gg,i);vm.m.t[nm]=ggml_get_tensor(vm.m.ctx,nm);}
+  auto need=[&](const std::string&n){ return vm.m.g(n)!=nullptr; };
+  vm.ok = need("cmvn.shift")&&need("cmvn.scale")&&need("encoder.in_linear1.linear.weight")
+        &&need("encoder.in_linear2.linear.weight")&&need("encoder.out_linear1.linear.weight")
+        &&need("encoder.out_linear2.linear.weight");
+  for(int i=0;i<vm.nl&&vm.ok;i++){std::string p="encoder.fsmn."+std::to_string(i)+".";
+    vm.ok=need(p+"linear.linear.weight")&&need(p+"fsmn_block.conv_left.weight")&&need(p+"affine.linear.weight");}
+  if(!vm.ok)fprintf(stderr,"vad: gguf missing required tensors\n");
+  return vm.ok;
+}
+static void funasr_vad_unload(vad_model& vm){
+  if(vm.gg)gguf_free(vm.gg);
+  if(vm.m.ctx)ggml_free(vm.m.ctx);
+  vm=vad_model{};
+}
+// scores[lfr_t] = silence prob for LFR frame lfr_t; feats are raw (pre-CMVN) [T x idim], row-major
+static bool funasr_vad_scores(vad_model& vm, const std::vector<float>& feats_in, int T,
+                              std::vector<float>& sil, int nthreads){
+  sil.assign(T,1.0f);
+  if(T<1)return true;
+  std::vector<float> feats=feats_in;
+  float*shift=(float*)vm.m.g("cmvn.shift")->data,*scale=(float*)vm.m.g("cmvn.scale")->data;
+  for(int t=0;t<T;t++)for(int d=0;d<vm.idim;d++)feats[(size_t)t*vm.idim+d]=(feats[(size_t)t*vm.idim+d]+shift[d])*scale[d];
+  auto&v=vm.m;
   ggml_backend_t be=ggml_backend_cpu_init();
   // no_alloc=true -> ctx holds only tensor/graph metadata (the real compute buffer is
   // allocated by gallocr below), so a few MB is plenty regardless of clip length.
   ggml_init_params cp={(size_t)16*1024*1024,nullptr,true}; ggml_context*c=ggml_init(cp);
-  ggml_tensor*x=ggml_new_tensor_2d(c,GGML_TYPE_F32,idim,T); ggml_set_input(x);
-  ggml_tensor*h=lin(c,m.g("encoder.in_linear1.linear.weight"),m.g("encoder.in_linear1.linear.bias"),x);
-  h=lin(c,m.g("encoder.in_linear2.linear.weight"),m.g("encoder.in_linear2.linear.bias"),h); h=ggml_relu(c,h);
-  for(int i=0;i<nl;i++){std::string p="encoder.fsmn."+std::to_string(i)+".";
-    ggml_tensor*z=ggml_mul_mat(c,m.g(p+"linear.linear.weight"),h);
-    ggml_tensor*fk=m.g(p+"fsmn_block.conv_left.weight"); ggml_tensor*zp=ggml_pad_ext(c,z,0,0,lorder-1,0,0,0,0,0); ggml_tensor*acc=z;
+  ggml_tensor*x=ggml_new_tensor_2d(c,GGML_TYPE_F32,vm.idim,T); ggml_set_input(x);
+  ggml_tensor*h=lin(c,v.g("encoder.in_linear1.linear.weight"),v.g("encoder.in_linear1.linear.bias"),x);
+  h=lin(c,v.g("encoder.in_linear2.linear.weight"),v.g("encoder.in_linear2.linear.bias"),h); h=ggml_relu(c,h);
+  for(int i=0;i<vm.nl;i++){std::string p="encoder.fsmn."+std::to_string(i)+".";
+    ggml_tensor*z=ggml_mul_mat(c,v.g(p+"linear.linear.weight"),h);
+    ggml_tensor*fk=v.g(p+"fsmn_block.conv_left.weight"); ggml_tensor*zp=ggml_pad_ext(c,z,0,0,vm.lorder-1,0,0,0,0,0); ggml_tensor*acc=z;
     // sl is a full-row slice of the contiguous padded tensor -> already contiguous, no ggml_cont needed
-    for(int j=0;j<lorder;j++){auto sl=ggml_view_2d(c,zp,pd,T,zp->nb[1],(size_t)j*zp->nb[1]);auto wj=ggml_view_1d(c,fk,pd,(size_t)j*fk->nb[1]);acc=ggml_add(c,acc,ggml_mul(c,sl,wj));}
-    ggml_tensor*a=lin(c,m.g(p+"affine.linear.weight"),m.g(p+"affine.linear.bias"),acc); h=ggml_relu(c,a);}
-  h=lin(c,m.g("encoder.out_linear1.linear.weight"),m.g("encoder.out_linear1.linear.bias"),h);
-  h=lin(c,m.g("encoder.out_linear2.linear.weight"),m.g("encoder.out_linear2.linear.bias"),h);
+    for(int j=0;j<vm.lorder;j++){auto sl=ggml_view_2d(c,zp,vm.pd,T,zp->nb[1],(size_t)j*zp->nb[1]);auto wj=ggml_view_1d(c,fk,vm.pd,(size_t)j*fk->nb[1]);acc=ggml_add(c,acc,ggml_mul(c,sl,wj));}
+    ggml_tensor*a=lin(c,v.g(p+"affine.linear.weight"),v.g(p+"affine.linear.bias"),acc); h=ggml_relu(c,a);}
+  h=lin(c,v.g("encoder.out_linear1.linear.weight"),v.g("encoder.out_linear1.linear.bias"),h);
+  h=lin(c,v.g("encoder.out_linear2.linear.weight"),v.g("encoder.out_linear2.linear.bias"),h);
   h=ggml_soft_max(c,h); ggml_set_output(h);
   ggml_cgraph*gf=ggml_new_graph(c); ggml_build_forward_expand(gf,h);
   ggml_gallocr_t ga=ggml_gallocr_new(ggml_backend_cpu_buffer_type()); ggml_gallocr_alloc_graph(ga,gf);
   ggml_backend_tensor_set(x,feats.data(),0,ggml_nbytes(x)); ggml_backend_cpu_set_n_threads(be,nthreads);
   bool ok=ggml_backend_graph_compute(be,gf)==GGML_STATUS_SUCCESS;
-  std::vector<float> sc((size_t)od*T); if(ok)ggml_backend_tensor_get(h,sc.data(),0,ggml_nbytes(h));
-  ggml_gallocr_free(ga);ggml_free(c);ggml_backend_free(be);if(m.ctx)ggml_free(m.ctx);
+  std::vector<float> sc((size_t)vm.od*T); if(ok)ggml_backend_tensor_get(h,sc.data(),0,ggml_nbytes(h));
+  ggml_gallocr_free(ga);ggml_free(c);ggml_backend_free(be);
   if(!ok)return false;
+  for(int t=0;t<T;t++)sil[t]=sc[(size_t)t*vm.od+0];
+  return true;
+}
 
-  // ===== E2EVadModel state machine (host) -> speech segments [start_ms,end_ms] =====
-  const int FR=10;                 // ms per frame (frame_in_ms)
-  const int win=20;                // window_size_ms 200 / 10
-  const int s2s=15, sp2s=15;       // sil_to_speech / speech_to_sil thres (150/10)
-  const int lookahead_end=100/FR;  // lookahead_time_end_point 100/10 = 10 (do_extend)
-  int max_seg = (max_seg_ms>0 ? max_seg_ms : 60000)/FR;       // max_single_segment frames
-  const int start_lookback = win + 200/FR;                   // LatencyFrmNumAtStartPoint = 40
-  // End-silence threshold from DEFAULT_SILENCE_SCHEDULE, stepped at chunk boundaries (chunk_size
-  // 60000ms = 6000 frames). At each boundary, if mid-segment (InSpeech) or in_speech latched,
-  // accumulated_ms += 60000; threshold = schedule(accumulated). Reset to 0 on each segment emit.
-  const int CHUNK=60000/FR;
-  int acc=0, insp=0; int max_end_sil, end_lookback;
-  auto recompute=[&](){
-    int s; if(acc<=10000)s=2000; else if(acc<=20000)s=1000; else if(acc<=30000)s=800;
-    else if(acc<=40000)s=600; else if(acc<=50000)s=400; else if(acc<=60000)s=200; else s=100;
-    int ms=s-150; if(ms<0)ms=0; max_end_sil=ms/FR;
-    end_lookback=max_end_sil-lookahead_end-1; if(end_lookback<0)end_lookback=0;
-  };
-  recompute();
-  std::vector<int> wbuf(win,0); int wpos=0,wsum=0,pre=0;
-  int st=0, cstart=-1, csil=0, prev_end=0;
-  auto reset=[&](){ std::fill(wbuf.begin(),wbuf.end(),0); wpos=0; wsum=0; pre=0; csil=0; st=0; cstart=-1; acc=0; insp=0; };
-  auto emit=[&](int s,int e){ if(s<prev_end)s=prev_end; if(s<0)s=0; if(e>T)e=T; if(e>s){segs.push_back({s,e}); prev_end=e;} };
-  for(int t=0;t<T;t++){
-    if(t>0 && t%CHUNK==0){ if(st==1||insp){acc+=60000; insp=1;} recompute(); }
-    float sil=sc[(size_t)t*od+0];
-    int fs = ((1.0f-sil) >= sil + 0.5f) ? 1 : 0;               // speech_noise_thres=0.5
+// ---- E2EVadModel state machine (host) ----
+// Stepped per LFR frame (10ms). dynamic_schedule=false reproduces the offline
+// fsmn-vad.generate behaviour (60s-chunk-stepped schedule); true follows
+// DynamicStreamingVAD's DEFAULT_SILENCE_SCHEDULE keyed on frames since the last emit.
+struct vad_machine{
+  static const int FR=10;                 // ms per frame (frame_in_ms)
+  int T_ms=0;                             // frames stepped so far (== frame count)
+  int max_seg=60000/FR;                   // max_single_segment frames
+  bool dynamic=false;
+  std::vector<int> wbuf; int win=20;      // window_size_ms 200 / FR
+  int wpos=0,wsum=0,pre=0;
+  int st=0,cstart=-1,csil=0,prev_end=0;
+  int acc=0,insp=0,last_emit=0;
+  vad_machine(int max_seg_ms=60000,bool dynamic_schedule=false){
+    max_seg=(max_seg_ms>0?max_seg_ms:60000)/FR; dynamic=dynamic_schedule;
+    wbuf.assign(win,0);
+  }
+  int max_end_sil(int t)const{
+    int ms;
+    if(!dynamic){
+      int s; if(acc<=10000)s=2000; else if(acc<=20000)s=1000; else if(acc<=30000)s=800;
+      else if(acc<=40000)s=600; else if(acc<=50000)s=400; else if(acc<=60000)s=200; else s=100;
+      ms=s;
+    } else {
+      int a=(t-last_emit)*FR;
+      int s; if(a<=5000)s=2000; else if(a<=10000)s=1500; else if(a<=15000)s=1000;
+      else if(a<=30000)s=800; else if(a<=45000)s=400; else s=100;
+      ms=s;
+    }
+    ms-=150; if(ms<0)ms=0; return ms/FR;
+  }
+  static int end_lookback(int mes){
+    const int lookahead_end=100/FR;       // lookahead_time_end_point 100/10 = 10 (do_extend)
+    int e=mes-lookahead_end-1; return e<0?0:e;
+  }
+  void reset(){ std::fill(wbuf.begin(),wbuf.end(),0); wpos=0; wsum=0; pre=0; csil=0; st=0; cstart=-1; acc=0; insp=0; }
+  // step one frame; appends frames-delimited segments to segs when confirmed
+  void step(int t, float sil, std::vector<std::pair<int,int>>& segs){
+    const int s2s=15, sp2s=15;            // sil_to_speech / speech_to_sil thres (150/10)
+    if(!dynamic && t>0 && t%(60000/FR)==0){ if(st==1||insp){acc+=60000; insp=1;} }
+    int mes=max_end_sil(t);
+    int elb=end_lookback(mes);
+    int fs = ((1.0f-sil) >= sil + 0.5f) ? 1 : 0;  // speech_noise_thres=0.5
     wsum -= wbuf[wpos]; wsum += fs; wbuf[wpos]=fs; wpos=(wpos+1)%win;
     int ch;
     if(pre==0 && wsum>=s2s){pre=1; ch=3;}
     else if(pre==1 && wsum<=sp2s){pre=0; ch=1;}
     else ch = pre==0?0:2;
+    auto emit=[&](int s,int e,int T){
+      if(s<prev_end)s=prev_end; if(s<0)s=0; if(e>T)e=T;
+      if(e>s){segs.push_back({s,e}); prev_end=e; last_emit=e;}
+    };
+    const int start_lookback = win + 200/FR;  // LatencyFrmNumAtStartPoint = 40
     if(ch==3){ csil=0;
       if(st==0){ cstart=t-start_lookback; if(cstart<prev_end)cstart=prev_end; if(cstart<0)cstart=0; st=1; }
-      else if(st==1 && t-cstart+1>max_seg){ emit(cstart,t); reset(); }
+      else if(st==1 && t-cstart+1>max_seg){ emit(cstart,t,T_ms+1); reset(); }
     } else if(ch==1||ch==2){ csil=0;
-      if(st==1 && t-cstart+1>max_seg){ emit(cstart,t); reset(); }
+      if(st==1 && t-cstart+1>max_seg){ emit(cstart,t,T_ms+1); reset(); }
     } else { csil++;
       if(st==1){
-        if(csil>=max_end_sil){ emit(cstart, t-end_lookback); reset(); }
-        else if(t-cstart+1>max_seg){ emit(cstart,t); reset(); }
+        if(csil>=mes){ emit(cstart, t-elb, T_ms+1); reset(); }
+        else if(t-cstart+1>max_seg){ emit(cstart,t,T_ms+1); reset(); }
       }
     }
+    T_ms=t+1;
   }
-  if(st==1) emit(cstart,T);
-  // convert frame indices -> ms
-  for(auto&s:segs){ s.first*=FR; s.second*=FR; }
+};
+} // namespace funasr_vad_impl
+
+// Full-buffer analysis. dynamic_schedule=false keeps the classic offline behaviour
+// (60s-chunk-stepped silence schedule, trailing in-progress speech flushed into segs).
+// dynamic_schedule=true follows DynamicStreamingVAD (serve_realtime_ws.py), keyed on
+// frames elapsed since the last emitted segment, and reports the in-progress segment
+// start in in_speech_start_ms_out (-1 when the trailing frames are not in speech).
+inline bool funasr_vad_analyze(const std::string& gguf_path, const std::vector<float>& wav,
+                               int max_seg_ms, bool dynamic_schedule,
+                               std::vector<std::pair<int,int>>& segs,
+                               int* in_speech_start_ms_out, int nthreads=8){
+  using namespace funasr_vad_impl;
+  segs.clear();
+  if(in_speech_start_ms_out)*in_speech_start_ms_out=-1;
+  vad_model vm;
+  if(!funasr_vad_load(gguf_path,vm)){funasr_vad_unload(vm);return false;}
+  auto feat=fbank80(wav); int T=0; auto rows=lfr(feat,vm.lm,vm.ln,T);   // [T,400]
+  std::vector<float> feats((size_t)T*vm.idim);
+  for(int t=0;t<T;t++)memcpy(&feats[(size_t)t*vm.idim],rows[t].data(),(size_t)vm.idim*sizeof(float));
+  std::vector<float> sil;
+  bool ok=funasr_vad_scores(vm,feats,T,sil,nthreads);
+  funasr_vad_unload(vm);
+  if(!ok)return false;
+  std::vector<std::pair<int,int>> segs_fr;
+  vad_machine mach(max_seg_ms,dynamic_schedule);
+  for(int t=0;t<T;t++)mach.step(t,sil[t],segs_fr);
+  if(in_speech_start_ms_out){
+    *in_speech_start_ms_out = (mach.st==1) ? mach.cstart*vad_machine::FR : -1;
+  } else if(mach.st==1){
+    int s=mach.cstart; if(s<mach.prev_end)s=mach.prev_end; if(s<0)s=0;
+    if(T>s)segs_fr.push_back({s,T});
+  }
+  for(auto&s:segs_fr){ s.first*=vad_machine::FR; s.second*=vad_machine::FR; segs.push_back(s); }
   return true;
+}
+
+// Backwards-compatible offline entry point (classic schedule, trailing speech flushed).
+inline bool funasr_vad_segments(const std::string& gguf_path, const std::vector<float>& wav,
+                                int max_seg_ms, std::vector<std::pair<int,int>>& segs, int nthreads=8){
+  return funasr_vad_analyze(gguf_path, wav, max_seg_ms, false, segs, nullptr, nthreads);
+}
+
+// ---- streaming session: irreversible DynamicStreamingVAD-style segment emission ----
+// Scores are computed incrementally: the FSMN stack has lorder-1 left context per layer
+// (nl layers -> (lorder-1)*nl frames) plus the 2-frame LFR left context, so scoring a
+// new block only needs a bounded rewind; the last 2 frames are unstable (LFR needs 2
+// future frames) and are recomputed on the next feed. The state machine steps only over
+// stable frames, which makes emissions identical to a full re-analysis.
+struct funasr_vad_stream {
+  std::string gguf_path;
+  funasr_vad_impl::vad_model vm;
+  std::vector<float> wav;                 // full session buffer, 16k mono [-1,1]
+  std::vector<float> sil;                 // stable-frame silence scores
+  size_t stable_frames=0;                 // frames scored+stepped so far
+  funasr_vad_impl::vad_machine mach;
+  std::vector<std::pair<int,int>> emitted;// confirmed segments, ms
+  int in_speech_start_ms=-1;
+  int nthreads=8;
+  funasr_vad_stream(const char*path,int max_seg_ms):mach(max_seg_ms>0?max_seg_ms:60000,true){
+    if(path)gguf_path=path;
+  }
+};
+inline void funasr_vad_stream_close(funasr_vad_stream* s);
+inline funasr_vad_stream* funasr_vad_stream_open(const char* gguf_path, int max_seg_ms){
+  auto* s=new funasr_vad_stream(gguf_path,max_seg_ms);
+  if(!funasr_vad_impl::funasr_vad_load(s->gguf_path,s->vm)){funasr_vad_stream_close(s);return nullptr;}
+  return s;
+}
+// Append samples; returns (via new_segs) segments confirmed since the previous call.
+inline bool funasr_vad_stream_feed(funasr_vad_stream* s, const float* pcm, size_t n,
+                                   std::vector<std::pair<int,int>>& new_segs){
+  using namespace funasr_vad_impl;
+  new_segs.clear();
+  if(!s||!s->vm.ok)return false;
+  if(pcm&&n)s->wav.insert(s->wav.end(),pcm,pcm+n);
+  const int N=(int)s->wav.size();
+  const int Tfb = N>=WINLEN ? (N-WINLEN)/SHIFT+1 : 0;    // fbank frames available
+  const int target = Tfb>=2 ? Tfb-2 : 0;                 // stable LFR frames
+  const int lb_frames = (s->vm.nl)*(s->vm.lorder-1);     // FSMN left context (e.g. 76)
+  if(target>(int)s->stable_frames){
+    int first=(int)s->stable_frames;
+    int w0 = first==0 ? 0 : first-lb_frames; if(w0<0)w0=0;
+    int w1 = target;
+    // score LFR frames [w0,w1): fbank frames [f0 .. f1) with LFR edge context
+    int f0 = w0-2; if(f0<0)f0=0;
+    int f1 = w1+2; if(f1>Tfb)f1=Tfb;
+    if(w1>w0&&f1>f0){
+      // slice audio aligned to fbank frame boundaries (frames are independent)
+      const float*base=s->wav.data()+(size_t)f0*SHIFT;
+      int nsamp=(int)std::min((int64_t)N-(int64_t)f0*SHIFT,(int64_t)(f1-1)*SHIFT+WINLEN-(int64_t)f0*SHIFT);
+      std::vector<float> slice(base,base+nsamp);
+      auto feat=fbank80(slice); int Tl=0; auto rows=lfr(feat,s->vm.lm,s->vm.ln,Tl);
+      // global LFR index i in [w0,w1) must resolve to local row (i - f0): true because
+      // lfr() over the slice of fbank frames [f0..) reproduces the same clamping only at
+      // global edges; for w0>0 no clamping occurs inside the window.
+      // NOTE: lfr()/fbank80() above keep the historical interface; the local row count
+      // covers [f0, f0+Tl).
+      std::vector<float> feats((size_t)(w1-w0)*s->vm.idim);
+      bool ok=true;
+      for(int i=w0;i<w1&&ok;i++){
+        int li=i-f0;
+        if(li<0||li>=Tl)ok=false;   // slice too short (audio truncated mid-frame)
+        else memcpy(&feats[(size_t)(i-w0)*s->vm.idim],rows[li].data(),(size_t)s->vm.idim*sizeof(float));
+      }
+      std::vector<float> sil_w;
+      ok=ok&&funasr_vad_scores(s->vm,feats,w1-w0,sil_w,s->nthreads);
+      if(!ok)return false;
+      // outputs are valid from w0 (edge-padded conv) when w0==0, else after the
+      // left-context warmup; keep frames [first, w1)
+      int keep0 = std::max(w0 + (w0>0?lb_frames:0), first);
+      for(int i=keep0;i<w1;i++)s->sil.push_back(sil_w[i-w0]);
+      if((int)s->sil.size()<w1 && keep0<w1)s->sil.resize(w1);  // keep indices aligned
+      std::vector<std::pair<int,int>> fr;
+      for(int t=first;t<w1;t++)s->mach.step(t,s->sil[t],fr);
+      s->stable_frames=w1;
+      for(auto&p:fr){ p.first*=vad_machine::FR; p.second*=vad_machine::FR; new_segs.push_back(p); s->emitted.push_back({p.first,p.second}); }
+      s->in_speech_start_ms = (s->mach.st==1) ? s->mach.cstart*vad_machine::FR : -1;
+    }
+  }
+  return true;
+}
+inline void funasr_vad_stream_close(funasr_vad_stream* s){
+  if(!s)return;
+  funasr_vad_impl::funasr_vad_unload(s->vm);
+  delete s;
 }

--- a/runtime/llama.cpp/tests/README.md
+++ b/runtime/llama.cpp/tests/README.md
@@ -9,9 +9,23 @@ state machine, the CIF predictor and CTC decode.
 # from runtime/llama.cpp/, after building (cmake --build build):
 ./tests/run_regression.sh              # VAD (tiny model auto-fetched) + any tool whose GGUF is already local
 RUN_FULL=1 ./tests/run_regression.sh   # also download the ASR GGUFs from Hugging Face and test every tool
+ALIGN_PYTHON=1 ./tests/run_regression.sh  # additionally align --stream VAD boundaries with
+                                         # python DynamicStreamingVAD (needs funasr + torch)
 ```
 `BIN_DIR` / `MODELS_DIR` override where binaries and GGUFs are found. Exit code is
 non-zero if any test fails; tools with no binary or no model are skipped.
+
+## Streaming (llama-funasr-cli --stream)
+
+`nano-stream` feeds `sample.wav` as raw s16le PCM (60ms chunks via `wav2pcm.py`) into
+`llama-funasr-cli --stream` and diffs the whole `LOCKED`/`PARTIAL`/`DONE` trace against
+`golden/nano-stream.txt`; `nano-stream-final` additionally asserts that the locked text,
+concatenated, equals the offline transcript (`golden/nano.txt`).
+
+`align_streaming_vad.py` cross-checks the streamed segment boundaries against FunASR's
+python `DynamicStreamingVAD` (the wrapper used by `serve_realtime_ws.py`) within 100ms,
+mirroring the realtime websocket server contract. It requires the `funasr` python package
+and torch (CPU is fine) and only runs under `ALIGN_PYTHON=1`.
 
 ## Golden
 Captured on Linux x86-64 (the reference platform) with the f16 GGUFs published at

--- a/runtime/llama.cpp/tests/align_streaming_vad.py
+++ b/runtime/llama.cpp/tests/align_streaming_vad.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""align_streaming_vad.py — cross-check the C++ streaming VAD against the Python one.
+
+Feeds a wav through FunASR's DynamicStreamingVAD (the same wrapper used by
+serve_realtime_ws.py) in 60ms chunks and compares the confirmed segment
+boundaries against the LOCKED timestamps that `llama-funasr-cli --stream`
+logs on stderr ("[stream] locked [START,ENDms] ...").
+
+  align_streaming_vad.py sample.wav                     # just print python segments
+  align_streaming_vad.py sample.wav --cpp locked.txt    # pass/fail vs C++ (tolerance 100ms)
+
+Requires the funasr python package + torch (CPU is fine); fsmn-vad is tiny.
+"""
+import argparse
+import sys
+import wave
+
+TOLERANCE_MS = 100
+
+
+def python_segments(wav_path):
+    import numpy as np
+    import torch
+    from funasr import AutoModel
+    from funasr.models.fsmn_vad_streaming.dynamic_vad import DynamicStreamingVAD
+
+    with wave.open(wav_path, "rb") as w:
+        if (w.getframerate(), w.getnchannels(), w.getsampwidth()) != (16000, 1, 2):
+            sys.exit("expected 16 kHz mono s16 wav")
+        audio = np.frombuffer(w.readframes(w.getnframes()), dtype=np.int16).astype(np.float32) / 32768.0
+
+    vad = DynamicStreamingVAD(AutoModel(model="fsmn-vad", device="cpu", disable_update=True))
+    segs = []
+    chunk = 960  # 60ms
+    for off in range(0, len(audio), chunk):
+        segs.extend(vad.feed(torch.from_numpy(audio[off:off + chunk]).float(), is_final=False))
+    segs.extend(vad.finalize())
+    return segs
+
+
+def cpp_segments(path):
+    segs = []
+    for line in open(path, encoding="utf-8"):
+        line = line.strip()
+        if line.startswith("[stream] locked ["):
+            span = line.split("[", 2)[2].split("]")[0].replace("ms", "")
+            start, end = span.split(",")
+            segs.append([int(start), int(end)])
+    return segs
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("wav")
+    ap.add_argument("--cpp", help="llama-funasr-cli --stream stderr log with locked lines")
+    args = ap.parse_args()
+
+    py_segs = python_segments(args.wav)
+    for s, e in py_segs:
+        print(f"python [{s},{e}ms]")
+
+    if not args.cpp:
+        return
+    cpp = cpp_segments(args.cpp)
+    if len(py_segs) != len(cpp):
+        sys.exit(f"FAIL: segment count differs: python={len(py_segs)} cpp={len(cpp)}")
+    for (ps, pe), (cs, ce) in zip(py_segs, cpp):
+        if abs(ps - cs) > TOLERANCE_MS or abs(pe - ce) > TOLERANCE_MS:
+            sys.exit(f"FAIL: python [{ps},{pe}] vs cpp [{cs},{ce}] (tolerance {TOLERANCE_MS}ms)")
+    print(f"PASS: {len(cpp)} segment(s) within {TOLERANCE_MS}ms of python DynamicStreamingVAD")
+
+
+if __name__ == "__main__":
+    main()

--- a/runtime/llama.cpp/tests/golden/nano-stream.txt
+++ b/runtime/llama.cpp/tests/golden/nano-stream.txt
@@ -1,0 +1,6 @@
+PARTIAL 我想。
+PARTIAL 我想问。
+PARTIAL 我想问我在滨海。
+PARTIAL 我想问我在滨海新区有房。
+LOCKED 我想问我在滨海新区有房。
+DONE

--- a/runtime/llama.cpp/tests/run_regression.sh
+++ b/runtime/llama.cpp/tests/run_regression.sh
@@ -48,5 +48,40 @@ B=$(bin llama-funasr-sensevoice) && run_tool sensevoice llama-funasr-sensevoice 
 B=$(bin llama-funasr-paraformer) && run_tool paraformer llama-funasr-paraformer paraformer.txt paraformer paraformer-f16.gguf -- "$B" -m "$MODELS/paraformer-f16.gguf" -a "$SAMPLE"
 B=$(bin llama-funasr-cli)        && run_tool nano       llama-funasr-cli        nano.txt       nano       funasr-encoder-f16.gguf qwen3-0.6b-q8_0.gguf -- "$B" --enc "$MODELS/funasr-encoder-f16.gguf" -m "$MODELS/qwen3-0.6b-q8_0.gguf" -a "$SAMPLE"
 
+# streaming mode: simulate a realtime PCM stream (60ms chunks) and diff the whole
+# LOCKED/PARTIAL/DONE protocol trace against the frozen golden.
+B=$(bin llama-funasr-cli)
+if [ -n "$B" ]; then
+  if ensure_models nano funasr-encoder-f16.gguf qwen3-0.6b-q8_0.gguf fsmn-vad.gguf fsmn-vad.gguf; then
+    got=$(python3 "$DIR/wav2pcm.py" "$SAMPLE" --chunk-ms 60 | "$B" --enc "$MODELS/funasr-encoder-f16.gguf" -m "$MODELS/qwen3-0.6b-q8_0.gguf" --vad "$MODELS/fsmn-vad.gguf" --stream 2>"$DIR/.nano-stream.stderr")
+    check nano-stream "$DIR/golden/nano-stream.txt" "$got"
+    # invariant: the locked stream text, concatenated, equals the offline transcript
+    # (the streamed window includes the trailing-silence tail, which can legitimately
+    # add a trailing punctuation mark -- strip sentence-final punctuation on both sides)
+    locked=$(printf %s "$got" | grep '^LOCKED ' | sed 's/^LOCKED //' | tr -d '\n')
+    locked_n=$locked; expected_n=$(cat "$DIR/golden/nano.txt")
+    for punc in 。 . , ! ? ！ ？; do locked_n=${locked_n%"$punc"}; expected_n=${expected_n%"$punc"}; done
+    if [ "$locked_n" = "$expected_n" ]; then echo "  PASS  nano-stream-final"; pass=$((pass+1))
+    else echo "  FAIL  nano-stream-final"; echo "    expected: $expected_n"; echo "    got:      $locked_n"; fail=$((fail+1)); fi
+    # optional: segment boundaries vs python DynamicStreamingVAD (needs funasr+torch)
+    if [ "${ALIGN_PYTHON:-0}" = 1 ]; then
+      if python3 -c 'import funasr, torch' 2>/dev/null; then
+        if python3 "$DIR/align_streaming_vad.py" "$SAMPLE" --cpp "$DIR/.nano-stream.stderr"; then
+          echo "  PASS  nano-stream-align"; pass=$((pass+1))
+        else
+          echo "  FAIL  nano-stream-align"; fail=$((fail+1))
+        fi
+      else
+        skipper nano-stream-align "funasr/torch not installed"
+      fi
+      rm -f "$DIR/.nano-stream.stderr"
+    fi
+  else
+    skipper nano-stream "model missing (set RUN_FULL=1)"
+  fi
+else
+  skipper nano-stream "no binary"
+fi
+
 echo "== $pass passed, $fail failed, $skip skipped =="
 [ "$fail" = 0 ]

--- a/runtime/llama.cpp/tests/wav2pcm.py
+++ b/runtime/llama.cpp/tests/wav2pcm.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""wav2pcm.py — dump a 16 kHz mono s16 WAV as raw little-endian PCM on stdout.
+
+Used by the llama-funasr-cli --stream regression test to simulate a PCM input
+stream. Stdlib only.
+
+  wav2pcm.py sample.wav                 # whole file at once
+  wav2pcm.py sample.wav --chunk-ms 60   # 60ms chunks
+  wav2pcm.py sample.wav --chunk-ms 960 --realtime  # also sleep between chunks
+"""
+import argparse
+import sys
+import time
+import wave
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("wav")
+    ap.add_argument("--chunk-ms", type=float, default=0,
+                    help="emit in N-ms chunks (default: whole file)")
+    ap.add_argument("--realtime", action="store_true",
+                    help="sleep one chunk between writes (realtime simulation)")
+    args = ap.parse_args()
+
+    with wave.open(args.wav, "rb") as w:
+        if (w.getframerate(), w.getnchannels(), w.getsampwidth()) != (16000, 1, 2):
+            sys.exit("wav2pcm: expected 16 kHz mono s16 wav, got "
+                     f"{w.getframerate()} Hz x {w.getnchannels()} ch x {w.getsampwidth()} B")
+        pcm = w.readframes(w.getnframes())
+
+    out = sys.stdout.buffer
+    chunk = int(args.chunk_ms * 16) * 2 if args.chunk_ms > 0 else len(pcm)
+    if chunk <= 0:
+        chunk = len(pcm)
+    for off in range(0, len(pcm), chunk):
+        out.write(pcm[off:off + chunk])
+        out.flush()
+        if args.realtime:
+            time.sleep(chunk / 2 / 16000.0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds a realtime streaming mode to the Fun-ASR-Nano llama.cpp CLI, mirroring the python `serve_realtime_ws.py` `RealtimeASRSession` contract so downstream apps (e.g. qwen-audio-toolkits) can consume the same LOCKED/PARTIAL semantics without a python runtime.

- `--stream`: raw 16 kHz mono s16le PCM on stdin; encoder + Qwen3 LLM + FSMN-VAD load once and stay resident. stdout line protocol: `LOCKED <text>` / `PARTIAL <text>` / `DONE`.
- Cadence and budgets follow the python session: first decode after 480 ms of audio then every 960 ms; 15 s partial-window cap; 200 / 512-token budgets for partial / locked decodes; EOF flushes the trailing in-progress segment; `--lang` emits the `语音转写成<language>：` prompt variant.
- `funasr_vad.h`: new incremental `funasr_vad_stream_*` handle. Scoring is feed-relative — the causal FSMN stack only rewinds a bounded 78 frames, so each feed costs O(new audio), not O(session). The E2EVadModel host machine steps `DynamicStreamingVAD`'s silence schedule and emits segments irreversibly. Offline `funasr_vad_segments()` behaviour is unchanged (covered by the existing `vad` golden).

## Tests

`tests/run_regression.sh` (with `tests/models` populated) passes locally on macOS arm64:

- `vad` / `nano` — unchanged offline goldens PASS
- `nano-stream` — new golden: whole LOCKED/PARTIAL/DONE trace on `sample.wav`
- `nano-stream-final` — invariant: concatenated LOCKED text equals the offline transcript
- `nano-stream-align` (`ALIGN_PYTHON=1`, new `tests/align_streaming_vad.py`) — boundary check vs `DynamicStreamingVAD`: **PASS, 1 segment within 100 ms** (`[770,6000]` vs python `[770,5990]`; the 10 ms is the EOF flush tail)

Note: `golden/nano-stream.txt` was captured on macOS arm64 with the same q8_0 GGUFs; offline `nano.txt` matches the Linux golden on this machine, so the trace should be portable — worth one reference-platform run to confirm.

Fixes the missing piece that made `--stream`-style UIs fall back to spawn-per-decode re-encoding.